### PR TITLE
fix: bump follow-redirects to 1.16.0 (GHSA-r4q5-vmmm-2653)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1666,9 +1666,9 @@
       }
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",


### PR DESCRIPTION
## Summary
- Resolves moderate severity advisory [GHSA-r4q5-vmmm-2653](https://github.com/advisories/GHSA-r4q5-vmmm-2653) — follow-redirects leaks custom Authorization headers to cross-domain redirect targets
- Transitive dependency via axios@1.15.0 (range ^1.15.11 → resolved to 1.16.0)
- Lock-file change only; no source changes

## Why now
The scheduled Security Scans workflow has been failing on main since Apr 14 (run 24378604070, 24434094934). `npm audit --audit-level=moderate` returns exit 1 on the current lock file. This PR clears the audit.

## Verification
```
$ npm audit
found 0 vulnerabilities
```

## Test plan
- [x] `npm audit` — clean
- [x] `npm test` — 94 tests pass (unchanged from main)
- [x] `npm run build` — clean