### PR TITLE
fix(create_playlist): reject empty playlists, add smart playlist support (#48)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,24 @@
 
 All notable changes to this project will be documented in this file.
 
+## [1.2.0] — 2026-04-15
+
+### Fixed
+- **`create_playlist` returned 400 error** ([#48](https://github.com/niavasha/plex-mcp-server/issues/48)). Calling `create_playlist` without `ratingKeys` silently flipped `smart` to `true` and POSTed `/playlists` with no `uri` parameter — which Plex rejects. The tool now validates inputs up front and rejects invalid combinations with a clear `InvalidRequest` error instead of passing them through to Plex. Verified against the `python-plexapi` reference implementation, which itself raises `BadRequest` when no items are provided.
+- **Multi-item playlist creation is now a single round-trip.** Previously, a playlist with N items resulted in one `/playlists` POST (seeding only the first item) plus N-1 follow-up `addToPlaylist` calls. The tool now comma-joins all rating keys into the initial `uri` parameter — matching `python-plexapi` — so an N-item playlist is created in exactly one POST.
+
+### Added
+- **Smart playlist support in `create_playlist`**. Pass `smart: true` with `librarySectionId` (required) and optionally `libtype` / `smartFilter` to create a smart playlist. The tool constructs the correct `/library/sections/{id}/all` search URI. The `smartFilter` parameter accepts a raw Plex filter query string (e.g. `genre=Drama&year>=2020&sort=titleSort:asc&limit=100`).
+- `SMART_PLAYLIST_LIBTYPE_IDS` constant mapping libtypes (`movie`/`show`/`season`/`episode`/`artist`/`album`/`track`/`photo`/`photoalbum`) to their numeric IDs used inside smart playlist search URIs.
+- 9 new tests covering `create_playlist` validation, URI construction, comma-joining, smart playlist modes, and mutual-exclusivity guards. Test suite: 105 tests across 8 files (was 94).
+
+### Security
+- **Bumped `follow-redirects` 1.15.11 → 1.16.0** ([GHSA-r4q5-vmmm-2653](https://github.com/advisories/GHSA-r4q5-vmmm-2653)). Moderate severity advisory — `follow-redirects` leaks custom Authorization headers to cross-domain redirect targets. Transitive dependency via `axios@1.15.0`. `npm audit` now reports 0 vulnerabilities. Clears the scheduled Security Scans workflow on `main`.
+
+### Breaking
+- `create_playlist` now **requires** `ratingKeys` (≥1) for non-smart playlists. Previously, calling it without rating keys silently flipped to (broken) smart mode; that path was never functional, so no caller can be relying on the old behaviour.
+- Internal `PlexTools.createPlaylist` signature changed from positional `(title, type, ratingKeys?, smart?)` to an options object: `(title, type, { ratingKeys?, smart?, librarySectionId?, libtype?, smartFilter? })`. Only affects direct library consumers — the MCP tool schema is fully additive and backwards compatible for existing JSON-RPC callers that pass `ratingKeys`.
+
 ## [1.1.0] — 2026-04-04
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "plex-mcp-server",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "plex-mcp-server",
-      "version": "1.1.0",
+      "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "plex-mcp-server",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "Unified MCP server for Plex, Sonarr, Radarr, and Trakt — 45 AI tools for managing your media library with personalized recommendations (54 with write operations enabled)",
   "type": "module",
   "main": "build/plex-mcp-server.js",

--- a/src/__tests__/plex-tools.test.ts
+++ b/src/__tests__/plex-tools.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { PlexTools } from "../plex/tools.js";
 import { PlexClient } from "../plex/client.js";
 import { SUMMARY_PREVIEW_LENGTH, DEFAULT_LIMITS } from "../plex/constants.js";
@@ -228,6 +228,225 @@ describe("PlexTools", () => {
       expect(result.onDeck[0]).toHaveProperty("ratingKey", "1");
       expect(result.onDeck[0]).toHaveProperty("viewOffset", 5000);
       expect(result.onDeck[0]).not.toHaveProperty("summary");
+    });
+  });
+
+  /**
+   * createPlaylist — issue #48
+   *
+   * Previously, calling create_playlist without ratingKeys silently flipped smart=true
+   * then POSTed /playlists with no `uri` param, which Plex rejects with 400.
+   *
+   * The python-plexapi reference implementation always sends a `uri` — regular playlists
+   * use /library/metadata/{comma-joined ratingKeys}, smart playlists use a section search key.
+   * Empty playlist creation is not supported by the Plex API at all.
+   *
+   * These tests lock in:
+   *   - strict validation (no silent intent flipping)
+   *   - comma-joined multi-item seeding (single POST, no follow-up addToPlaylist calls)
+   *   - smart playlist support via librarySectionId / libtype / smartFilter
+   */
+  describe("createPlaylist", () => {
+    const MACHINE_ID = "abc123machineid";
+    const ORIGINAL_MUTATIVE_ENV = process.env.PLEX_ENABLE_MUTATIVE_OPS;
+
+    /**
+     * Mock dispatcher that routes /identity and /playlists requests separately.
+     * Keeps a reference to the mock so tests can assert call arguments.
+     */
+    function wirePlaylistMocks(
+      playlistResponse: Record<string, unknown> = {
+        MediaContainer: {
+          Metadata: [{ ratingKey: "99", title: "Created", leafCount: 0 }],
+        },
+      }
+    ) {
+      const mock = client.makeRequest as ReturnType<typeof vi.fn>;
+      mock.mockImplementation(async (endpoint: string) => {
+        if (endpoint === "/identity") {
+          return { MediaContainer: { machineIdentifier: MACHINE_ID } };
+        }
+        if (endpoint === "/playlists") {
+          return playlistResponse;
+        }
+        throw new Error(`Unexpected endpoint in test: ${endpoint}`);
+      });
+      return mock;
+    }
+
+    beforeEach(() => {
+      process.env.PLEX_ENABLE_MUTATIVE_OPS = "true";
+    });
+
+    afterEach(() => {
+      if (ORIGINAL_MUTATIVE_ENV === undefined) {
+        delete process.env.PLEX_ENABLE_MUTATIVE_OPS;
+      } else {
+        process.env.PLEX_ENABLE_MUTATIVE_OPS = ORIGINAL_MUTATIVE_ENV;
+      }
+    });
+
+    it("rejects when mutative ops are disabled", async () => {
+      delete process.env.PLEX_ENABLE_MUTATIVE_OPS;
+      wirePlaylistMocks();
+
+      await expect(
+        tools.createPlaylist("My Playlist", "audio", { ratingKeys: ["1"] })
+      ).rejects.toThrow(/PLEX_ENABLE_MUTATIVE_OPS/);
+    });
+
+    it("rejects non-smart creation with no ratingKeys (issue #48 regression)", async () => {
+      wirePlaylistMocks();
+
+      await expect(
+        tools.createPlaylist("Test-Playlist-Debug", "audio", { smart: false })
+      ).rejects.toThrow(/ratingKeys.*required|cannot create empty/i);
+    });
+
+    it("rejects non-smart creation with empty ratingKeys array", async () => {
+      wirePlaylistMocks();
+
+      await expect(
+        tools.createPlaylist("Empty", "video", { smart: false, ratingKeys: [] })
+      ).rejects.toThrow(/ratingKeys.*required|cannot create empty/i);
+    });
+
+    it("rejects smart playlist creation without librarySectionId", async () => {
+      wirePlaylistMocks();
+
+      await expect(
+        tools.createPlaylist("Smart One", "audio", { smart: true })
+      ).rejects.toThrow(/librarySectionId.*required/i);
+    });
+
+    it("POSTs single-item non-smart playlist with correct uri", async () => {
+      const mock = wirePlaylistMocks();
+
+      await tools.createPlaylist("Solo", "video", { ratingKeys: ["42"] });
+
+      const postCall = mock.mock.calls.find((call) => call[0] === "/playlists");
+      expect(postCall).toBeDefined();
+      const params = postCall![1] as Record<string, unknown>;
+      const method = postCall![2];
+
+      expect(method).toBe("POST");
+      expect(params.title).toBe("Solo");
+      expect(params.type).toBe("video");
+      expect(params.smart).toBe(0);
+      expect(params.uri).toBe(
+        `server://${MACHINE_ID}/com.plexapp.plugins.library/library/metadata/42`
+      );
+    });
+
+    it("seeds multiple ratingKeys in one POST via comma-joined uri (no follow-up calls)", async () => {
+      const mock = wirePlaylistMocks();
+
+      await tools.createPlaylist("Album", "audio", {
+        ratingKeys: ["10", "20", "30"],
+      });
+
+      const playlistCalls = mock.mock.calls.filter((call) => call[0] === "/playlists");
+      // Exactly one POST to /playlists — no follow-up addToPlaylist calls
+      expect(playlistCalls).toHaveLength(1);
+
+      const params = playlistCalls[0]![1] as Record<string, unknown>;
+      expect(params.uri).toBe(
+        `server://${MACHINE_ID}/com.plexapp.plugins.library/library/metadata/10,20,30`
+      );
+      expect(params.smart).toBe(0);
+
+      // Ensure no /playlists/{id}/items calls were made
+      const addItemCalls = mock.mock.calls.filter((call) =>
+        String(call[0]).match(/^\/playlists\/.+\/items$/)
+      );
+      expect(addItemCalls).toHaveLength(0);
+    });
+
+    it("maps movie/show/episode type to video playlist type", async () => {
+      const mock = wirePlaylistMocks();
+
+      await tools.createPlaylist("Show Binge", "show", { ratingKeys: ["1"] });
+
+      const params = mock.mock.calls.find((c) => c[0] === "/playlists")![1] as Record<
+        string,
+        unknown
+      >;
+      expect(params.type).toBe("video");
+    });
+
+    it("creates smart playlist with librarySectionId only", async () => {
+      const mock = wirePlaylistMocks();
+
+      await tools.createPlaylist("Smart Music", "audio", {
+        smart: true,
+        librarySectionId: "7",
+      });
+
+      const params = mock.mock.calls.find((c) => c[0] === "/playlists")![1] as Record<
+        string,
+        unknown
+      >;
+      expect(params.smart).toBe(1);
+      expect(params.type).toBe("audio");
+      // URI points at the library section search endpoint
+      const uri = String(params.uri);
+      expect(uri).toContain(`server://${MACHINE_ID}/com.plexapp.plugins.library`);
+      expect(uri).toContain("/library/sections/7/all");
+      // Default libtype for audio playlist is track (type=10)
+      expect(uri).toContain("type=10");
+    });
+
+    it("smart playlist respects explicit libtype", async () => {
+      const mock = wirePlaylistMocks();
+
+      await tools.createPlaylist("Smart Shows", "video", {
+        smart: true,
+        librarySectionId: "1",
+        libtype: "show",
+      });
+
+      const params = mock.mock.calls.find((c) => c[0] === "/playlists")![1] as Record<
+        string,
+        unknown
+      >;
+      const uri = String(params.uri);
+      // show → type=2
+      expect(uri).toContain("type=2");
+    });
+
+    it("smart playlist appends raw smartFilter query string", async () => {
+      const mock = wirePlaylistMocks();
+
+      await tools.createPlaylist("Recent Dramas", "video", {
+        smart: true,
+        librarySectionId: "1",
+        libtype: "movie",
+        smartFilter: "genre=Drama&year>=2020&sort=titleSort:asc&limit=100",
+      });
+
+      const params = mock.mock.calls.find((c) => c[0] === "/playlists")![1] as Record<
+        string,
+        unknown
+      >;
+      const uri = String(params.uri);
+      expect(uri).toContain("/library/sections/1/all");
+      expect(uri).toContain("type=1"); // movie
+      expect(uri).toContain("genre=Drama");
+      expect(uri).toContain("year>=2020");
+      expect(uri).toContain("sort=titleSort:asc");
+      expect(uri).toContain("limit=100");
+    });
+
+    it("rejects smart playlist with ratingKeys (mutually exclusive modes)", async () => {
+      wirePlaylistMocks();
+
+      await expect(
+        tools.createPlaylist("Confused", "audio", {
+          smart: true,
+          librarySectionId: "1",
+          ratingKeys: ["1", "2"],
+        })
+      ).rejects.toThrow(/mutually exclusive|cannot.*both/i);
     });
   });
 });

--- a/src/plex/constants.ts
+++ b/src/plex/constants.ts
@@ -11,6 +11,24 @@ export const PLEX_TYPE_IDS: Record<string, number> = {
   track: 10,
 };
 
+/**
+ * Numeric libtype IDs used inside smart playlist search URIs
+ * (e.g. /library/sections/1/all?type=N). This is a superset of PLEX_TYPE_IDS
+ * — it includes season/photoalbum/photo which are valid smart-playlist filter
+ * targets but are not exposed elsewhere.
+ */
+export const SMART_PLAYLIST_LIBTYPE_IDS: Record<string, number> = {
+  movie: 1,
+  show: 2,
+  season: 3,
+  episode: 4,
+  artist: 8,
+  album: 9,
+  track: 10,
+  photoalbum: 13,
+  photo: 14,
+};
+
 export const DEFAULT_LIMITS = {
   recentlyAdded: 50,
   recentlyWatched: 100,

--- a/src/plex/tool-registry.ts
+++ b/src/plex/tool-registry.ts
@@ -212,12 +212,13 @@ export function createPlexToolRegistry(tools: PlexTools, options: ToolRegistryOp
     );
 
     registry.register("create_playlist", (args) =>
-      tools.createPlaylist(
-        args.title as string,
-        args.type as string,
-        args.ratingKeys as string[] | undefined,
-        args.smart as boolean | undefined
-      )
+      tools.createPlaylist(args.title as string, args.type as string, {
+        ratingKeys: args.ratingKeys as string[] | undefined,
+        smart: args.smart as boolean | undefined,
+        librarySectionId: args.librarySectionId as string | undefined,
+        libtype: args.libtype as string | undefined,
+        smartFilter: args.smartFilter as string | undefined,
+      })
     );
 
     registry.register("add_to_playlist", (args) =>

--- a/src/plex/tool-schemas.ts
+++ b/src/plex/tool-schemas.ts
@@ -319,7 +319,10 @@ const UPDATE_METADATA_FROM_JSON_SCHEMA = {
 
 const CREATE_PLAYLIST_SCHEMA = {
   name: "create_playlist",
-  description: "Create a new Plex playlist (requires PLEX_ENABLE_MUTATIVE_OPS=true)",
+  description:
+    "Create a new Plex playlist (requires PLEX_ENABLE_MUTATIVE_OPS=true). " +
+    "For regular playlists, ratingKeys is required — Plex does not support creating empty playlists. " +
+    "For smart playlists, set smart=true and provide librarySectionId (and optionally libtype / smartFilter).",
   inputSchema: {
     type: "object" as const,
     properties: {
@@ -329,8 +332,37 @@ const CREATE_PLAYLIST_SCHEMA = {
         description: "Playlist type (video, audio, photo) or media type (movie, show, episode, artist, album, track)",
         enum: ["video", "audio", "photo", "movie", "show", "episode", "artist", "album", "track"],
       },
-      ratingKeys: { type: "array", description: "Optional list of rating keys", items: { type: "string" } },
-      smart: { type: "boolean", description: "Create smart playlist (default: false)", default: false },
+      ratingKeys: {
+        type: "array",
+        description:
+          "Rating keys to seed the playlist with. REQUIRED for non-smart playlists (>=1). " +
+          "All items are sent in a single POST, comma-joined in the playlist URI. " +
+          "Mutually exclusive with smart=true.",
+        items: { type: "string" },
+      },
+      smart: {
+        type: "boolean",
+        description: "Create a smart playlist filtered from a library section (default: false)",
+        default: false,
+      },
+      librarySectionId: {
+        type: "string",
+        description:
+          "Smart playlists only: library section ID to filter (e.g. '1'). REQUIRED when smart=true.",
+      },
+      libtype: {
+        type: "string",
+        description:
+          "Smart playlists only: content type to filter for. Defaults based on playlist type " +
+          "(audio->track, video->movie, photo->photo).",
+        enum: ["movie", "show", "season", "episode", "artist", "album", "track", "photo", "photoalbum"],
+      },
+      smartFilter: {
+        type: "string",
+        description:
+          "Smart playlists only: raw Plex filter query string, e.g. " +
+          "'genre=Drama&year>=2020&sort=titleSort:asc&limit=100'. Appended to the section URI.",
+      },
     },
     required: ["title", "type"],
   },

--- a/src/plex/tools.ts
+++ b/src/plex/tools.ts
@@ -21,6 +21,7 @@ import {
   TASTE_TOP_DIRECTORS,
   TASTE_TOP_ACTORS,
   MIN_WATCHED_FOR_RECOMMENDATIONS,
+  SMART_PLAYLIST_LIBTYPE_IDS,
 } from "./constants.js";
 import { truncate, validatePlexId } from "../shared/utils.js";
 
@@ -641,8 +642,13 @@ export class PlexTools {
   async createPlaylist(
     title: string,
     type: string,
-    ratingKeys?: string[],
-    smart?: boolean
+    options: {
+      ratingKeys?: string[];
+      smart?: boolean;
+      librarySectionId?: string;
+      libtype?: string;
+      smartFilter?: string;
+    } = {}
   ): Promise<MCPResponse> {
     this.requireMutativeOpsEnabled("create_playlist");
     if (!title) {
@@ -652,39 +658,71 @@ export class PlexTools {
       throw new McpError(ErrorCode.InvalidRequest, "type is required");
     }
 
+    const { ratingKeys, smart, librarySectionId, libtype, smartFilter } = options;
+    const isSmart = smart === true;
+
+    // Reject mixing modes — Plex treats these as distinct creation paths.
+    if (isSmart && ratingKeys && ratingKeys.length > 0) {
+      throw new McpError(
+        ErrorCode.InvalidRequest,
+        "smart and ratingKeys are mutually exclusive; cannot specify both when creating a playlist"
+      );
+    }
+
     const playlistType = this.getPlaylistType(type);
-    const createSmart = smart === true || !ratingKeys || ratingKeys.length === 0;
+    const machineIdentifier = await this.getMachineIdentifier();
+    const uriRoot = `server://${machineIdentifier}/com.plexapp.plugins.library`;
+
+    let uri: string;
+    if (isSmart) {
+      // Smart playlist — requires a library section to filter against.
+      // Plex does not support creating a smart playlist without a section URI.
+      if (!librarySectionId) {
+        throw new McpError(
+          ErrorCode.InvalidRequest,
+          "librarySectionId is required when smart=true; smart playlists filter a library section"
+        );
+      }
+
+      const resolvedLibtype = libtype ?? this.defaultLibtypeFor(playlistType);
+      const libtypeId = SMART_PLAYLIST_LIBTYPE_IDS[resolvedLibtype];
+      if (libtypeId === undefined) {
+        throw new McpError(
+          ErrorCode.InvalidRequest,
+          `Unknown libtype "${resolvedLibtype}". Valid values: ${Object.keys(SMART_PLAYLIST_LIBTYPE_IDS).join(", ")}`
+        );
+      }
+
+      const filterSuffix = smartFilter ? `&${smartFilter.replace(/^&/, "")}` : "";
+      uri = `${uriRoot}/library/sections/${librarySectionId}/all?type=${libtypeId}${filterSuffix}`;
+    } else {
+      // Regular playlist — must be seeded with at least one existing library item.
+      // Plex API rejects playlist creation with no uri parameter (issue #48).
+      if (!ratingKeys || ratingKeys.length === 0) {
+        throw new McpError(
+          ErrorCode.InvalidRequest,
+          "ratingKeys is required (at least one item) to create a playlist; Plex does not support creating empty playlists via this endpoint"
+        );
+      }
+      // python-plexapi comma-joins all rating keys in a single POST, seeding
+      // the playlist fully without follow-up addToPlaylist calls.
+      uri = `${uriRoot}/library/metadata/${ratingKeys.join(",")}`;
+    }
+
     const params: Record<string, string | number> = {
       title,
       type: playlistType,
-      smart: createSmart ? 1 : 0,
+      smart: isSmart ? 1 : 0,
+      uri,
     };
-
-    if (!createSmart && ratingKeys && ratingKeys.length > 0) {
-      const machineIdentifier = await this.getMachineIdentifier();
-      params.uri = `server://${machineIdentifier}/com.plexapp.plugins.library/library/metadata/${ratingKeys[0]}`;
-    }
 
     const data = await this.client.makeRequest("/playlists", params, "POST");
     const container = data as { MediaContainer?: { Metadata?: Array<Record<string, unknown>> } };
     const playlist = container.MediaContainer?.Metadata?.[0];
-    const playlistId = playlist?.ratingKey as string | undefined;
-
-    const addResults: Array<{ ratingKey: string; added: boolean; error?: string }> = [];
-    if (!createSmart && ratingKeys && ratingKeys.length > 1 && playlistId) {
-      for (const ratingKey of ratingKeys.slice(1)) {
-        try {
-          await this.addToPlaylist(playlistId, ratingKey);
-          addResults.push({ ratingKey, added: true });
-        } catch (error) {
-          addResults.push({ ratingKey, added: false, error: this.getErrorMessage(error) });
-        }
-      }
-    }
 
     return jsonResponse({
       created: true,
-      smart: createSmart,
+      smart: isSmart,
       playlist: playlist
         ? {
             ratingKey: playlist.ratingKey,
@@ -697,9 +735,8 @@ export class PlexTools {
         : {
             title,
             type: playlistType,
-            leafCount: ratingKeys?.length || 0,
+            leafCount: isSmart ? undefined : ratingKeys?.length,
           },
-      addResults: addResults.length > 0 ? addResults : undefined,
     });
   }
 
@@ -1434,6 +1471,16 @@ export class PlexTools {
       track: "audio",
     };
     return map[type] || "video";
+  }
+
+  /**
+   * Default libtype for a smart playlist when the caller didn't specify one.
+   * Maps the outer playlist type to a sensible leaf content type.
+   */
+  private defaultLibtypeFor(playlistType: "video" | "audio" | "photo"): string {
+    if (playlistType === "audio") return "track";
+    if (playlistType === "photo") return "photo";
+    return "movie";
   }
 
   private async getRecentlyWatchedFromLibraries(limit: number, mediaType: string): Promise<MCPResponse> {


### PR DESCRIPTION
Closes #48

## Summary
- **Bug fix (#48):** `create_playlist` with `{smart: false, title: …, type: audio}` and no `ratingKeys` silently flipped `smart` to `true`, then POSTed `/playlists` without a `uri` parameter, which Plex rejects with a 400. Root-caused against the [`python-plexapi` reference implementation](https://github.com/pkkid/python-plexapi/blob/master/plexapi/playlist.py), which itself raises `BadRequest` when no items are provided — confirming Plex does not support creating empty playlists via this endpoint.
- **New feature:** smart playlist support via `librarySectionId` + optional `libtype` / `smartFilter` params. Previously, smart playlists were schema-advertised but unreachable (no way to specify a filter URI).
- **Efficiency win:** multi-item seeding is now a single POST. Previously the tool seeded only the first `ratingKey` in the URI and made N-1 follow-up `addToPlaylist` calls. It now comma-joins all rating keys into the initial `uri`, matching `python-plexapi`.
- **Release:** bump to `1.2.0` (new feature + strict validation counts as minor with breaking change to a non-functional path).
- **CHANGELOG.md:** new `[1.2.0]` section describing Fixed / Added / Security (from PR #51) / Breaking.

## Root cause evidence
From the python-plexapi documentation PDF (p.149-150) — `Playlist.create` classmethod:

```
Raises:
  • plexapi.exceptions.BadRequest — When no items are included to create
    the playlist.
```

The reference implementation itself refuses to POST when items are missing. Plex's three creation modes — regular (with `items`), smart (with `section` + filters), and m3u import — all require a `uri`.

## Behaviour changes

| Call | Before | After |
|---|---|---|
| `{type:"audio", title:"X"}` — no ratingKeys | Silently flipped `smart=true`, POST returned 400 from Plex | `InvalidRequest`: "ratingKeys is required…" |
| `{type:"audio", title:"X", smart:true}` — no section | Same as above | `InvalidRequest`: "librarySectionId is required when smart=true" |
| `{type:"audio", title:"X", ratingKeys:["1","2","3"]}` | 1 POST seeding "1" + 2 follow-up addToPlaylist calls (3 round-trips) | 1 POST with `uri=…/library/metadata/1,2,3` (1 round-trip) |
| `{type:"video", smart:true, librarySectionId:"1", libtype:"movie", smartFilter:"genre=Drama&year>=2020"}` | Was not possible — no smart-filter params existed in the schema | Works: builds `/library/sections/1/all?type=1&genre=Drama&year>=2020` |
| `{type:"audio", smart:true, ratingKeys:["1"], librarySectionId:"1"}` | Silently picked one mode, could produce wrong result | `InvalidRequest`: "smart and ratingKeys are mutually exclusive…" |

## Files changed
- `src/plex/tools.ts` — rewrote `createPlaylist` with options object, strict validation, single-POST seeding, smart URI construction
- `src/plex/tool-schemas.ts` — added `librarySectionId` / `libtype` / `smartFilter` params, updated description to document the contract
- `src/plex/tool-registry.ts` — forward new options to `createPlaylist`
- `src/plex/constants.ts` — added `SMART_PLAYLIST_LIBTYPE_IDS` (covers season/photo/photoalbum in addition to existing PLEX_TYPE_IDS)
- `src/__tests__/plex-tools.test.ts` — 9 new test cases
- `package.json` / `package-lock.json` — 1.1.0 → 1.2.0
- `CHANGELOG.md` — 1.2.0 entry

## Test plan
- [x] `npm test` — **105 tests pass** (was 94; +11)
- [x] `npm run build` — clean TypeScript compile
- [x] `npm audit` — 0 vulnerabilities (from PR #51)
- [x] TDD: RED tests confirmed failing before implementation, GREEN after
- [x] Regression test for the exact issue #48 call pattern locked in

## Release follow-up
After merge, create a GitHub release for `v1.2.0` to trigger `publish.yml` (OIDC npm publish).