### PR TITLE
feat: get_active_sessions + multi-session HTTP transport (carries #89)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+node_modules
+build
+.git
+.github
+.env
+.env.*
+*.log
+coverage
+docs
+*.pdf
+CHANGELOG.md
+CONTRIBUTORS.md
+README.md

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -32,3 +32,19 @@ updates:
           - "*"
     reviewers:
       - "niavasha"
+
+  # Base images in the Dockerfile (node:22-slim in both build and runtime
+  # stages). Without this, a base image with a published CVE would go
+  # unnoticed — npm audit only sees package.json, not the image.
+  - package-ecosystem: "docker"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+    open-pull-requests-limit: 5
+    groups:
+      docker:
+        patterns:
+          - "*"
+    reviewers:
+      - "niavasha"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,3 +34,93 @@ jobs:
 
       - name: Run tests
         run: npm test
+
+  # A push of N commits fires one workflow run, against the head SHA only, so
+  # every commit between the previous head and the new one lands on main having
+  # never been compiled or tested. That is invisible until someone bisects and
+  # hits a commit that cannot build. This job walks the range and builds each
+  # non-merge commit individually.
+  per-commit:
+    name: Per-commit build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v7
+        with:
+          node-version: "24"
+          cache: npm
+
+      - name: Resolve the commit range
+        id: range
+        env:
+          EVENT: ${{ github.event_name }}
+          BASE: ${{ github.event.pull_request.base.sha || github.event.before }}
+          HEAD: ${{ github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -euo pipefail
+          # A new branch, or a force push, reports an all-zero "before".
+          if [ -z "$BASE" ] || [ "$BASE" = "0000000000000000000000000000000000000000" ]; then
+            echo "No usable base ref for $EVENT — checking the head commit only."
+            RANGE="$HEAD~1..$HEAD"
+          else
+            RANGE="$BASE..$HEAD"
+          fi
+          # --no-merges: merge commits carry no changes of their own, and the
+          # merged result is already covered by the Build & Test job above.
+          git rev-list --no-merges --reverse "$RANGE" > commits.txt || true
+          COUNT=$(wc -l < commits.txt | tr -d ' ')
+          echo "count=$COUNT" >> "$GITHUB_OUTPUT"
+          echo "Range $RANGE contains $COUNT non-merge commit(s)."
+
+      - name: Build and test each commit
+        if: steps.range.outputs.count != '0'
+        env:
+          MAX_COMMITS: 25
+        run: |
+          set -uo pipefail
+          COUNT=$(wc -l < commits.txt | tr -d ' ')
+
+          # Bound the work on very large pushes. Anything skipped is named
+          # explicitly — a silent cap would read as "everything passed".
+          if [ "$COUNT" -gt "$MAX_COMMITS" ]; then
+            echo "::warning::$COUNT commits exceeds MAX_COMMITS=$MAX_COMMITS."
+            echo "::warning::Only the newest $MAX_COMMITS will be built. NOT built:"
+            head -n "$((COUNT - MAX_COMMITS))" commits.txt | while read -r s; do
+              echo "::warning::  skipped $(git log -1 --format='%h %s' "$s")"
+            done
+            tail -n "$MAX_COMMITS" commits.txt > trimmed.txt && mv trimmed.txt commits.txt
+          fi
+
+          LOCK_STATE=""
+          FAILED=0
+          while read -r sha; do
+            [ -n "$sha" ] || continue
+            echo "::group::$(git log -1 --format='%h %s' "$sha")"
+            git checkout --quiet --detach "$sha"
+
+            # Reinstall only when the lockfile actually changed — npm ci per
+            # commit dominates the runtime otherwise.
+            NEW_LOCK=$(git hash-object package-lock.json 2>/dev/null || echo none)
+            if [ "$NEW_LOCK" != "$LOCK_STATE" ]; then
+              npm ci --silent || { echo "::error::npm ci failed at $sha"; FAILED=1; echo "::endgroup::"; break; }
+              LOCK_STATE="$NEW_LOCK"
+            fi
+
+            if ! npm run build --silent; then
+              echo "::error::build failed at $(git log -1 --format='%h %s' "$sha")"
+              FAILED=1; echo "::endgroup::"; break
+            fi
+            if ! npm test --silent; then
+              echo "::error::tests failed at $(git log -1 --format='%h %s' "$sha")"
+              FAILED=1; echo "::endgroup::"; break
+            fi
+            echo "::endgroup::"
+          done < commits.txt
+
+          exit $FAILED

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v7
@@ -43,10 +45,20 @@ jobs:
   per-commit:
     name: Per-commit build
     runs-on: ubuntu-latest
+    # Build & Test already executes fork code once per PR, which is the normal
+    # `pull_request` bargain: read-only token, no secrets. This job would run
+    # `npm ci` + `npm test` once per commit, multiplying that by the length of
+    # the branch, so restrict it to code that already has write access here.
+    # Fork commits are not left unchecked: when the PR merges, the push event
+    # covers the whole range and builds each commit individually.
+    if: >-
+      github.event_name == 'push' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
         with:
+          persist-credentials: false
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.sha || github.sha }}
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -15,6 +15,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v7
@@ -37,6 +39,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v7
@@ -61,6 +65,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
+        with:
+          persist-credentials: false
 
       - name: Setup Node.js
         uses: actions/setup-node@v7

--- a/.github/workflows/security-compliance.yml
+++ b/.github/workflows/security-compliance.yml
@@ -17,6 +17,8 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v7
+      with:
+        persist-credentials: false
     
     - name: Check for security policy
       run: |
@@ -89,6 +91,8 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v7
+      with:
+        persist-credentials: false
     
     - name: Validate security documentation
       run: |
@@ -132,6 +136,8 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v7
+      with:
+        persist-credentials: false
     
     - name: Create secrets baseline
       run: |

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -125,17 +125,33 @@ jobs:
         npx license-checker --onlyAllow 'MIT;Apache-2.0;BSD-2-Clause;BSD-3-Clause;ISC;Unlicense;MPL-2.0'
 
   dockerfile-security:
-    name: Dockerfile Security (if applicable)
+    name: Dockerfile Security
     runs-on: ubuntu-latest
-    if: contains(github.event.head_commit.message, 'docker') || contains(github.event.pull_request.title, 'docker')
-    
+    # Previously gated on the commit message or PR title mentioning "docker",
+    # which made sense when the repo had no Dockerfile. Now that one is
+    # committed, that condition means the image is only linted when someone
+    # happens to use the word — so an unrelated change could break the image
+    # and skip the check entirely. The job now always runs; the lint step is
+    # gated on the file actually being present, which can only be evaluated
+    # after checkout.
     steps:
     - name: Checkout code
       uses: actions/checkout@v7
       with:
         persist-credentials: false
-    
+
+    - name: Look for a Dockerfile
+      id: detect
+      run: |
+        if [ -f Dockerfile ]; then
+          echo "found=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "found=false" >> "$GITHUB_OUTPUT"
+          echo "No Dockerfile in the repo — nothing to lint."
+        fi
+
     - name: Run Hadolint
+      if: steps.detect.outputs.found == 'true'
       uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5 # v3.3.0
       with:
         dockerfile: Dockerfile

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -20,6 +20,8 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v7
+      with:
+        persist-credentials: false
     
     - name: Setup Node.js
       uses: actions/setup-node@v7
@@ -58,6 +60,8 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v7
+      with:
+        persist-credentials: false
     
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v4
@@ -88,6 +92,7 @@ jobs:
     - name: Checkout code
       uses: actions/checkout@v7
       with:
+        persist-credentials: false
         fetch-depth: 0
     
     - name: Run TruffleHog
@@ -102,6 +107,8 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v7
+      with:
+        persist-credentials: false
     
     - name: Setup Node.js
       uses: actions/setup-node@v7
@@ -125,6 +132,8 @@ jobs:
     steps:
     - name: Checkout code
       uses: actions/checkout@v7
+      with:
+        persist-credentials: false
     
     - name: Run Hadolint
       uses: hadolint/hadolint-action@2332a7b74a6de0dda2e2221d575162eba76ba5e5 # v3.3.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [Unreleased]
+
+### Added
+- **`get_active_sessions`**: new tool that queries `/status/sessions` and returns active streams with user, player state, session location, transcode decisions, and media details. Enables AI assistants to answer "who is watching what right now."
+
 ## [1.2.0] — 2026-04-15
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to this project will be documented in this file.
 
 ### Added
 - **`get_active_sessions`**: new tool that queries `/status/sessions` and returns active streams with user, player state, session location, transcode decisions, and media details. Enables AI assistants to answer "who is watching what right now."
+- **`Dockerfile`**: multi-stage Node 20 image for containerized deployment of the MCP server.
+
+### Fixed
+- **Multi-session HTTP transport**: Replace single shared transport with per-session transport map. One `McpServer` instance per session, stored by ID and reused on subsequent requests. Closes sessions after 300s idle. Fixes concurrent agents receiving `400 already initialized` errors when sharing a single server instance.
 
 ## [1.2.0] — 2026-04-15
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,11 +5,20 @@ All notable changes to this project will be documented in this file.
 ## [Unreleased]
 
 ### Added
-- **`get_active_sessions`**: new tool that queries `/status/sessions` and returns active streams with user, player state, session location, transcode decisions, and media details. Enables AI assistants to answer "who is watching what right now."
-- **`Dockerfile`**: multi-stage Node 20 image for containerized deployment of the MCP server.
+- **`get_active_sessions`** — new Plex tool returning currently active streams: who is watching, what they are watching, player state and platform, session location (lan/wan/cellular), transcode decisions, and media quality. Lets an assistant answer "who is watching what right now." Contributed by [Jeremy Mulenex (@poedenon)](https://github.com/poedenon) in [#89](https://github.com/niavasha/plex-mcp-server/pull/89). Plex tool count 19 → 20; 46 tools total (55 with write operations enabled).
+- 13 tests covering `get_active_sessions`, including a regression test for the `Media` array shape described below.
+- **`Dockerfile` and `.dockerignore`** — multi-stage build (Node 22) that compiles in a build stage with devDependencies and ships a production-only runtime image running as the unprivileged `node` user, with a `/health` HEALTHCHECK. Based on the Dockerfile contributed in [#89](https://github.com/niavasha/plex-mcp-server/pull/89).
+- **Session capacity and body-size limits** for HTTP transport, configurable via `MCP_MAX_SESSIONS` (default 64) and `SESSION_TIMEOUT_SECONDS` (default 300). Request bodies over 4 MB are rejected with `413`.
+- 27 tests covering session lifecycle, idle expiry, body limits and concurrent HTTP clients.
 
 ### Fixed
-- **Multi-session HTTP transport**: Replace single shared transport with per-session transport map. One `McpServer` instance per session, stored by ID and reused on subsequent requests. Closes sessions after 300s idle. Fixes concurrent agents receiving `400 already initialized` errors when sharing a single server instance.
+- **`get_active_sessions` read `Media` as an object rather than a list.** The Plex API returns `Media` as an array (python-plexapi: `media (List<Media>)`), so accessing `.videoResolution` on it yielded `undefined` for every stream while still producing a well-formed response. Now reads the first media entry. Caught while adding test coverage to [#89](https://github.com/niavasha/plex-mcp-server/pull/89).
+- **`sessionCount` is now derived from the sessions actually returned** rather than trusting `MediaContainer.size`, which can be stale or reflect paging.
+- **Concurrent HTTP clients failed with `400 already initialized`.** A single shared `Server` instance backed every HTTP connection, but its initialization state is per-connection, so the second client to connect was rejected. Each session now gets its own `Server` and transport, keyed by session ID. Diagnosed by [Jeremy Mulenex (@poedenon)](https://github.com/poedenon) in [#89](https://github.com/niavasha/plex-mcp-server/pull/89). Running more than one agent against one HTTP instance no longer requires a second server process.
+- **Idle sessions were closed regardless of activity.** In the original fix, per-request activity was written to a field the expiry check never read, so every session was torn down 300s after creation even under continuous traffic. Activity is now recorded on the session entry itself and the idle deadline moves with it.
+- **Unbounded request body read.** The HTTP handler accumulated the request body with no ceiling, so an unauthenticated `POST /mcp` could exhaust process memory. Bodies are now capped and oversized requests rejected with `413`.
+- **Unbounded session creation and leaked timers.** Every request without a session header created a transport, a `Server` and a `setInterval`, with no limit and no guaranteed cleanup path. Sessions are now capped (`503` when full) and swept by a single unref'd timer instead of one timer per session.
+- **`DELETE /mcp` now tears a session down** and frees its slot, and `GET`/`DELETE` are routed without attempting to parse a request body.
 
 ## [1.2.0] — 2026-04-15
 

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,41 @@
+# Contributors
+
+This project is better than it would have been because of the people below.
+Thank you.
+
+Listed in order of first contribution.
+
+## Maintainer
+
+- **Harry Manley** ([@niavasha](https://github.com/niavasha)) — author and maintainer
+
+## Contributors
+
+- **[@punkpeye](https://github.com/punkpeye)** — added the MCP server registry badge
+  ([#1](https://github.com/niavasha/plex-mcp-server/pull/1)), the project's first
+  outside contribution.
+
+- **Robert Molenkamp** ([@rolo20](https://github.com/rolo20)) — built out the
+  read-only Plex tool surface and hardened `export_library`
+  ([#16](https://github.com/niavasha/plex-mcp-server/pull/16)), then designed the
+  opt-in mutative tool set behind `PLEX_ENABLE_MUTATIVE_OPS`
+  ([#17](https://github.com/niavasha/plex-mcp-server/pull/17)). The
+  safe-by-default posture of the write operations is his design.
+
+- **Jeremy Mulenex** ([@poedenon](https://github.com/poedenon)) — proposed and
+  implemented the `get_active_sessions` tool, and diagnosed the multi-session
+  HTTP transport bug that caused concurrent MCP clients to fail with
+  `400 already initialized`
+  ([#89](https://github.com/niavasha/plex-mcp-server/pull/89)). Correctly
+  identified that a single shared `McpServer` instance cannot back multiple
+  transports — the root cause behind needing a second server instance to run
+  more than one agent.
+
+## Adding yourself
+
+If you've had a change merged and you're not listed here, that's an oversight
+rather than a judgement — please open a PR adding yourself, or an issue and
+we'll do it for you.
+
+See [the Contributing section of the README](README.md#contributing) to get
+started.

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,20 @@
+FROM node:20-slim
+
+WORKDIR /app
+
+# Copy package files and install dependencies
+COPY package*.json ./
+RUN npm ci --only=production && npm cache clean --force
+
+# Copy source and build artifacts
+COPY tsconfig.json ./
+COPY src/ ./src/
+COPY build/ ./build/
+
+# Build (in case there are any TS changes)
+RUN npm run build 2>/dev/null || true
+
+EXPOSE 3100
+
+ENTRYPOINT ["node", "build/plex-mcp-server.js"]
+CMD ["--transport", "http", "--port", "3100"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,20 +1,38 @@
-FROM node:20-slim
+# syntax=docker/dockerfile:1
+
+# ── Build stage ───────────────────────────────────────────────────────────────
+# Needs devDependencies (typescript) to compile, so this cannot be the runtime
+# image. build/ is gitignored, so it is produced here rather than copied in.
+FROM node:22-slim AS build
 
 WORKDIR /app
 
-# Copy package files and install dependencies
-COPY package*.json ./
-RUN npm ci --only=production && npm cache clean --force
+COPY package.json package-lock.json ./
+RUN npm ci
 
-# Copy source and build artifacts
 COPY tsconfig.json ./
 COPY src/ ./src/
-COPY build/ ./build/
+RUN npm run build
 
-# Build (in case there are any TS changes)
-RUN npm run build 2>/dev/null || true
+# ── Runtime stage ─────────────────────────────────────────────────────────────
+FROM node:22-slim AS runtime
 
-EXPOSE 3100
+ENV NODE_ENV=production
+
+WORKDIR /app
+
+COPY package.json package-lock.json ./
+RUN npm ci --omit=dev && npm cache clean --force
+
+COPY --from=build /app/build ./build
+
+# Drop privileges — the node image ships an unprivileged `node` user.
+USER node
+
+EXPOSE 3000
+
+HEALTHCHECK --interval=30s --timeout=3s --start-period=5s --retries=3 \
+  CMD node -e "fetch('http://127.0.0.1:'+(process.env.MCP_PORT||3000)+'/health').then(r=>process.exit(r.ok?0:1)).catch(()=>process.exit(1))"
 
 ENTRYPOINT ["node", "build/plex-mcp-server.js"]
-CMD ["--transport", "http", "--port", "3100"]
+CMD ["--transport", "http"]

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ Once configured, you can ask your AI assistant:
 
 ## Available Functions
 
-### Plex Tools (19 tools)
+### Plex Tools (20 tools)
 
 | Function | Description |
 |----------|-------------|
@@ -178,10 +178,13 @@ Once configured, you can ask your AI assistant:
 | `get_library_stats` | Library usage metrics |
 | `get_popular_content` | Most popular content analysis |
 | `get_recommendations` | Personalized movie recommendations based on your watch history |
+| `get_active_sessions` | Currently active Plex streams (who is watching what, player state, transcoding) |
 
 ### Write Operations (9 tools, opt-in)
 
 Set `PLEX_ENABLE_MUTATIVE_OPS=true` to enable these tools. They allow your AI assistant to make changes to your Plex server. **Use with care** — while we test these tools, there are no guarantees. Review changes your assistant proposes before confirming.
+
+46 tools out of the box (55 with write operations enabled).
 
 | Function | Description |
 |----------|-------------|

--- a/README.md
+++ b/README.md
@@ -155,6 +155,8 @@ Once configured, you can ask your AI assistant:
 
 ## Available Functions
 
+46 tools out of the box (55 with write operations enabled).
+
 ### Plex Tools (20 tools)
 
 | Function | Description |
@@ -178,13 +180,11 @@ Once configured, you can ask your AI assistant:
 | `get_library_stats` | Library usage metrics |
 | `get_popular_content` | Most popular content analysis |
 | `get_recommendations` | Personalized movie recommendations based on your watch history |
-| `get_active_sessions` | Currently active Plex streams (who is watching what, player state, transcoding) |
+| `get_active_sessions` | Currently active Plex streams — who is watching what, player state, transcoding |
 
 ### Write Operations (9 tools, opt-in)
 
 Set `PLEX_ENABLE_MUTATIVE_OPS=true` to enable these tools. They allow your AI assistant to make changes to your Plex server. **Use with care** — while we test these tools, there are no guarantees. Review changes your assistant proposes before confirming.
-
-46 tools out of the box (55 with write operations enabled).
 
 | Function | Description |
 |----------|-------------|
@@ -329,6 +329,8 @@ npm run dev
 
 Contributions are welcome! Please feel free to submit a Pull Request. For major changes, please open an issue first to discuss what you would like to change.
 
+Merged contributors are credited in [CONTRIBUTORS.md](CONTRIBUTORS.md).
+
 ### Development Guidelines
 
 1. **Fork the repository**
@@ -399,6 +401,7 @@ This project is licensed under the MIT License - see the [LICENSE](LICENSE) file
 
 ## Acknowledgments
 
+- **[Everyone who has contributed code](CONTRIBUTORS.md)** — this project is not a solo effort
 - [Anthropic](https://anthropic.com/) for the Model Context Protocol
 - [Plex](https://www.plex.tv/) for the amazing media server
 - [Tautulli](https://tautulli.com/) for analytics inspiration

--- a/package-lock.json
+++ b/package-lock.json
@@ -685,6 +685,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -702,6 +705,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -719,6 +725,9 @@
         "ppc64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -736,6 +745,9 @@
         "s390x"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -753,6 +765,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -770,6 +785,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2455,6 +2473,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2476,6 +2497,9 @@
         "arm64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2497,6 +2521,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "glibc"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2518,6 +2545,9 @@
         "x64"
       ],
       "dev": true,
+      "libc": [
+        "musl"
+      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/package-lock.json
+++ b/package-lock.json
@@ -685,9 +685,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -705,9 +702,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -725,9 +719,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -745,9 +736,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -765,9 +753,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -785,9 +770,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2473,9 +2455,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2497,9 +2476,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2521,9 +2497,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2545,9 +2518,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/src/__tests__/active-sessions.test.ts
+++ b/src/__tests__/active-sessions.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { PlexTools } from "../plex/tools.js";
+import { PlexClient } from "../plex/client.js";
+import { SUMMARY_PREVIEW_LENGTH } from "../plex/constants.js";
+
+/** Create a mock PlexClient without hitting any real server */
+function createMockClient() {
+  return {
+    makeRequest: vi.fn(),
+    getPlexTypeId: vi.fn(() => 1),
+  } as unknown as PlexClient;
+}
+
+/** Parse the JSON text from an MCP response */
+function parseResponse(response: { content: Array<{ text: string }> }) {
+  return JSON.parse(response.content[0].text);
+}
+
+function mockSessions(client: PlexClient, container: unknown) {
+  (client.makeRequest as ReturnType<typeof vi.fn>).mockResolvedValue(container);
+}
+
+/** A realistic /status/sessions payload. Note Media is an ARRAY — see
+ *  python-plexapi: "media (List<Media>) – List of media objects." */
+const FULL_SESSION = {
+  MediaContainer: {
+    size: 1,
+    Metadata: [
+      {
+        ratingKey: "12345",
+        sessionKey: "9",
+        title: "The Wire",
+        type: "episode",
+        grandparentTitle: "The Wire",
+        parentTitle: "Season 1",
+        summary: "Short summary",
+        duration: 3600000,
+        viewOffset: 120000,
+        User: { title: "harry" },
+        Player: { title: "Living Room TV", state: "playing", platform: "tvOS" },
+        Session: { location: "lan" },
+        TranscodeSession: { videoDecision: "transcode", audioDecision: "copy" },
+        Media: [
+          { videoResolution: "4k", videoCodec: "hevc", audioCodec: "eac3" },
+        ],
+      },
+    ],
+  },
+};
+
+describe("PlexTools.getActiveSessions", () => {
+  let client: ReturnType<typeof createMockClient>;
+  let tools: PlexTools;
+
+  beforeEach(() => {
+    client = createMockClient();
+    tools = new PlexTools(client as unknown as PlexClient);
+  });
+
+  it("queries the /status/sessions endpoint", async () => {
+    mockSessions(client, FULL_SESSION);
+    await tools.getActiveSessions();
+    expect(client.makeRequest).toHaveBeenCalledWith("/status/sessions");
+  });
+
+  it("returns core stream identity fields", async () => {
+    mockSessions(client, FULL_SESSION);
+    const s = parseResponse(await tools.getActiveSessions()).activeSessions[0];
+
+    expect(s).toMatchObject({
+      ratingKey: "12345",
+      title: "The Wire",
+      type: "episode",
+      grandparentTitle: "The Wire",
+      parentTitle: "Season 1",
+      duration: 3600000,
+      viewOffset: 120000,
+    });
+  });
+
+  it("reports who is watching, on what, and in what state", async () => {
+    mockSessions(client, FULL_SESSION);
+    const s = parseResponse(await tools.getActiveSessions()).activeSessions[0];
+
+    expect(s.user).toBe("harry");
+    expect(s.player).toEqual({
+      title: "Living Room TV",
+      state: "playing",
+      platform: "tvOS",
+    });
+    expect(s.session).toEqual({ location: "lan" });
+  });
+
+  it("reports transcode decisions", async () => {
+    mockSessions(client, FULL_SESSION);
+    const s = parseResponse(await tools.getActiveSessions()).activeSessions[0];
+
+    expect(s.transcode).toEqual({
+      videoDecision: "transcode",
+      audioDecision: "copy",
+    });
+  });
+
+  // Regression: Media is a LIST in the Plex API. Reading it as an object
+  // yields undefined for every field while still producing valid-looking JSON.
+  it("reads media details from the Media array, not as an object", async () => {
+    mockSessions(client, FULL_SESSION);
+    const s = parseResponse(await tools.getActiveSessions()).activeSessions[0];
+
+    expect(s.media).toEqual({
+      videoResolution: "4k",
+      videoCodec: "hevc",
+      audioCodec: "eac3",
+    });
+  });
+
+  it("exposes sessionKey so a specific stream can be identified", async () => {
+    mockSessions(client, FULL_SESSION);
+    const s = parseResponse(await tools.getActiveSessions()).activeSessions[0];
+    expect(s.sessionKey).toBe("9");
+  });
+
+  it("returns an empty list when nothing is playing", async () => {
+    mockSessions(client, { MediaContainer: { size: 0 } });
+    const result = parseResponse(await tools.getActiveSessions());
+
+    expect(result.activeSessions).toEqual([]);
+    expect(result.sessionCount).toBe(0);
+  });
+
+  it("derives sessionCount from the returned sessions, not a trusted size field", async () => {
+    mockSessions(client, {
+      MediaContainer: {
+        size: 99, // Plex can report a stale/paged size
+        Metadata: [{ ratingKey: "1", title: "A" }, { ratingKey: "2", title: "B" }],
+      },
+    });
+    const result = parseResponse(await tools.getActiveSessions());
+    expect(result.sessionCount).toBe(2);
+  });
+
+  it("handles a session with no user, player, transcode or media blocks", async () => {
+    mockSessions(client, {
+      MediaContainer: { size: 1, Metadata: [{ ratingKey: "1", title: "Bare" }] },
+    });
+    const s = parseResponse(await tools.getActiveSessions()).activeSessions[0];
+
+    expect(s.user).toBeNull();
+    expect(s.player).toBeNull();
+    expect(s.session).toBeNull();
+    expect(s.transcode).toBeNull();
+    expect(s.media).toBeNull();
+  });
+
+  it("treats an empty Media array as no media rather than throwing", async () => {
+    mockSessions(client, {
+      MediaContainer: { size: 1, Metadata: [{ ratingKey: "1", title: "X", Media: [] }] },
+    });
+    const s = parseResponse(await tools.getActiveSessions()).activeSessions[0];
+    expect(s.media).toBeNull();
+  });
+
+  it("truncates long summaries to the project-wide preview length", async () => {
+    mockSessions(client, {
+      MediaContainer: {
+        size: 1,
+        Metadata: [{ ratingKey: "1", title: "X", summary: "A".repeat(2000) }],
+      },
+    });
+    const s = parseResponse(await tools.getActiveSessions()).activeSessions[0];
+
+    expect(s.summary.length).toBeLessThanOrEqual(SUMMARY_PREVIEW_LENGTH + 3);
+    expect(s.summary.startsWith("AAA")).toBe(true);
+  });
+
+  it("omits summary when the session has none", async () => {
+    mockSessions(client, {
+      MediaContainer: { size: 1, Metadata: [{ ratingKey: "1", title: "X" }] },
+    });
+    const s = parseResponse(await tools.getActiveSessions()).activeSessions[0];
+    expect(s.summary).toBeUndefined();
+  });
+
+  it("tolerates a MediaContainer with no Metadata key at all", async () => {
+    mockSessions(client, { MediaContainer: {} });
+    const result = parseResponse(await tools.getActiveSessions());
+    expect(result.activeSessions).toEqual([]);
+    expect(result.sessionCount).toBe(0);
+  });
+});

--- a/src/__tests__/transport-sessions.test.ts
+++ b/src/__tests__/transport-sessions.test.ts
@@ -1,0 +1,393 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { Readable } from "node:stream";
+import { createServer, type Server as HttpServer } from "node:http";
+import type { AddressInfo } from "node:net";
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import { Client } from "@modelcontextprotocol/sdk/client/index.js";
+import { StreamableHTTPClientTransport } from "@modelcontextprotocol/sdk/client/streamableHttp.js";
+import { ListToolsRequestSchema } from "@modelcontextprotocol/sdk/types.js";
+import type { IncomingMessage } from "node:http";
+
+import {
+  SessionStore,
+  SessionLimitError,
+  BodyTooLargeError,
+  readBody,
+  createMcpRequestHandler,
+  DEFAULT_MAX_BODY_BYTES,
+} from "../shared/transport.js";
+
+// ── helpers ──────────────────────────────────────────────────────────────────
+
+/** Minimal stand-in for a StreamableHTTPServerTransport. */
+function fakeTransport(sessionId: string) {
+  return {
+    sessionId,
+    close: vi.fn().mockResolvedValue(undefined),
+    onclose: undefined as (() => void) | undefined,
+  };
+}
+
+/** Turn a string into something shaped like an IncomingMessage. */
+function fakeRequest(body: string): IncomingMessage {
+  return Readable.from([Buffer.from(body)]) as unknown as IncomingMessage;
+}
+
+// ── readBody ─────────────────────────────────────────────────────────────────
+
+describe("readBody", () => {
+  it("reads a complete body", async () => {
+    const body = JSON.stringify({ jsonrpc: "2.0", method: "ping", id: 1 });
+    await expect(readBody(fakeRequest(body), 1024)).resolves.toBe(body);
+  });
+
+  it("reads an empty body as an empty string", async () => {
+    await expect(readBody(fakeRequest(""), 1024)).resolves.toBe("");
+  });
+
+  // Regression: the body was previously accumulated with no upper bound, so an
+  // unauthenticated POST to /mcp could exhaust process memory.
+  it("rejects a body larger than the limit", async () => {
+    const huge = "x".repeat(5000);
+    await expect(readBody(fakeRequest(huge), 1024)).rejects.toBeInstanceOf(
+      BodyTooLargeError
+    );
+  });
+
+  it("enforces the limit across chunks, not just per chunk", async () => {
+    const req = Readable.from([
+      Buffer.from("x".repeat(600)),
+      Buffer.from("x".repeat(600)),
+    ]) as unknown as IncomingMessage;
+
+    await expect(readBody(req, 1024)).rejects.toBeInstanceOf(BodyTooLargeError);
+  });
+
+  it("accepts a body exactly at the limit", async () => {
+    const exact = "x".repeat(1024);
+    await expect(readBody(fakeRequest(exact), 1024)).resolves.toHaveLength(1024);
+  });
+});
+
+// ── SessionStore ─────────────────────────────────────────────────────────────
+
+describe("SessionStore", () => {
+  let clock: number;
+  const now = () => clock;
+
+  beforeEach(() => {
+    clock = 1_000_000;
+  });
+
+  function makeStore(overrides: Partial<{ maxSessions: number; idleTimeoutMs: number }> = {}) {
+    return new SessionStore({
+      maxSessions: overrides.maxSessions ?? 4,
+      idleTimeoutMs: overrides.idleTimeoutMs ?? 300_000,
+      now,
+    });
+  }
+
+  it("stores and retrieves a session by id", () => {
+    const store = makeStore();
+    const t = fakeTransport("abc");
+    store.add(t as never);
+
+    expect(store.size).toBe(1);
+    expect(store.get("abc")).toBe(t);
+  });
+
+  it("returns undefined for an unknown session id", () => {
+    expect(makeStore().get("nope")).toBeUndefined();
+  });
+
+  // Regression: every POST without a session header created a transport, a
+  // server and a timer, with no ceiling.
+  it("refuses to exceed maxSessions", () => {
+    const store = makeStore({ maxSessions: 2 });
+    store.add(fakeTransport("a") as never);
+    store.add(fakeTransport("b") as never);
+
+    expect(() => store.add(fakeTransport("c") as never)).toThrow(SessionLimitError);
+    expect(store.size).toBe(2);
+  });
+
+  it("frees capacity when a session is closed", () => {
+    const store = makeStore({ maxSessions: 1 });
+    store.add(fakeTransport("a") as never);
+    store.close("a");
+
+    expect(store.size).toBe(0);
+    expect(() => store.add(fakeTransport("b") as never)).not.toThrow();
+  });
+
+  it("sweeps sessions idle beyond the timeout", () => {
+    const store = makeStore({ idleTimeoutMs: 300_000 });
+    const t = fakeTransport("stale");
+    store.add(t as never);
+
+    clock += 300_001;
+    const closed = store.sweep();
+
+    expect(closed).toEqual(["stale"]);
+    expect(store.size).toBe(0);
+    expect(t.close).toHaveBeenCalled();
+  });
+
+  it("does not sweep a session that is still within the timeout", () => {
+    const store = makeStore({ idleTimeoutMs: 300_000 });
+    store.add(fakeTransport("fresh") as never);
+
+    clock += 299_000;
+
+    expect(store.sweep()).toEqual([]);
+    expect(store.size).toBe(1);
+  });
+
+  // THE core regression from PR #89: activity was written to a dead field, so
+  // the idle deadline never moved and every session died 300s after creation
+  // no matter how busy it was.
+  it("keeps an actively used session alive indefinitely", () => {
+    const store = makeStore({ idleTimeoutMs: 300_000 });
+    store.add(fakeTransport("busy") as never);
+
+    // Simulate 20 minutes of traffic, one request every 4 minutes.
+    for (let i = 0; i < 5; i++) {
+      clock += 240_000;
+      expect(store.get("busy")).toBeDefined();
+      expect(store.sweep()).toEqual([]);
+    }
+
+    expect(store.size).toBe(1);
+  });
+
+  it("treats get() as activity", () => {
+    const store = makeStore({ idleTimeoutMs: 300_000 });
+    store.add(fakeTransport("x") as never);
+
+    clock += 299_000;
+    store.get("x"); // touch
+    clock += 299_000;
+
+    expect(store.sweep()).toEqual([]);
+  });
+
+  it("expires a session that goes quiet after being busy", () => {
+    const store = makeStore({ idleTimeoutMs: 300_000 });
+    store.add(fakeTransport("x") as never);
+
+    clock += 100_000;
+    store.get("x");
+    clock += 300_001;
+
+    expect(store.sweep()).toEqual(["x"]);
+  });
+
+  it("sweeps only the stale sessions, leaving fresh ones", () => {
+    const store = makeStore({ idleTimeoutMs: 300_000 });
+    store.add(fakeTransport("old") as never);
+    clock += 200_000;
+    store.add(fakeTransport("new") as never);
+    clock += 150_000; // old: 350s idle, new: 150s idle
+
+    expect(store.sweep()).toEqual(["old"]);
+    expect(store.has("new")).toBe(true);
+  });
+
+  it("closing a session detaches onclose so close does not recurse", () => {
+    const store = makeStore();
+    const t = fakeTransport("a");
+    let oncloseCalls = 0;
+    store.add(t as never);
+    t.onclose = () => {
+      oncloseCalls++;
+      store.close("a");
+    };
+
+    store.close("a");
+
+    expect(oncloseCalls).toBe(0);
+    expect(store.size).toBe(0);
+  });
+
+  it("closing an unknown session is a no-op", () => {
+    const store = makeStore();
+    expect(() => store.close("ghost")).not.toThrow();
+  });
+
+  it("closeAll closes every session and empties the store", () => {
+    const store = makeStore();
+    const a = fakeTransport("a");
+    const b = fakeTransport("b");
+    store.add(a as never);
+    store.add(b as never);
+
+    store.closeAll();
+
+    expect(store.size).toBe(0);
+    expect(a.close).toHaveBeenCalled();
+    expect(b.close).toHaveBeenCalled();
+  });
+});
+
+// ── HTTP handler integration ─────────────────────────────────────────────────
+
+/** Build a trivial but real MCP server exposing one tool. */
+function buildTestServer() {
+  const server = new Server(
+    { name: "test-server", version: "0.0.0" },
+    { capabilities: { tools: {} } }
+  );
+  server.setRequestHandler(ListToolsRequestSchema, async () => ({
+    tools: [
+      { name: "ping", description: "ping", inputSchema: { type: "object" as const, properties: {} } },
+    ],
+  }));
+  return server;
+}
+
+describe("MCP HTTP handler", () => {
+  let httpServer: HttpServer;
+  let baseUrl: string;
+  let store: SessionStore;
+  let serversCreated: number;
+
+  beforeEach(async () => {
+    serversCreated = 0;
+    store = new SessionStore({ maxSessions: 4, idleTimeoutMs: 300_000 });
+
+    const handler = createMcpRequestHandler({
+      getServer: () => {
+        serversCreated++;
+        return buildTestServer();
+      },
+      serverName: "test-server",
+      store,
+      // Small cap so the oversize test stays fast and deterministic; the
+      // production default is asserted separately below.
+      maxBodyBytes: 2048,
+    });
+
+    httpServer = createServer(handler);
+    await new Promise<void>((resolve) => httpServer.listen(0, "127.0.0.1", resolve));
+    const { port } = httpServer.address() as AddressInfo;
+    baseUrl = `http://127.0.0.1:${port}`;
+  });
+
+  afterEach(async () => {
+    store.closeAll();
+    await new Promise<void>((resolve) => httpServer.close(() => resolve()));
+  });
+
+  it("serves a health check", async () => {
+    const res = await fetch(`${baseUrl}/health`);
+    expect(res.status).toBe(200);
+    await expect(res.json()).resolves.toMatchObject({ status: "ok" });
+  });
+
+  it("404s an unknown path", async () => {
+    const res = await fetch(`${baseUrl}/nope`);
+    expect(res.status).toBe(404);
+  });
+
+  it("rejects a body over the size cap with 413", async () => {
+    const res = await fetch(`${baseUrl}/mcp`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "x".repeat(8192),
+    });
+    expect(res.status).toBe(413);
+  });
+
+  it("ships a sane production body cap", () => {
+    expect(DEFAULT_MAX_BODY_BYTES).toBeGreaterThan(64 * 1024);
+    expect(DEFAULT_MAX_BODY_BYTES).toBeLessThanOrEqual(16 * 1024 * 1024);
+  });
+
+  it("returns a JSON-RPC parse error for malformed JSON", async () => {
+    const res = await fetch(`${baseUrl}/mcp`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Accept: "application/json, text/event-stream" },
+      body: "{not json",
+    });
+    expect(res.status).toBe(400);
+    await expect(res.json()).resolves.toMatchObject({
+      error: { code: -32700 },
+    });
+  });
+
+  it("404s a request carrying an unknown session id", async () => {
+    const res = await fetch(`${baseUrl}/mcp`, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Accept: "application/json, text/event-stream",
+        "mcp-session-id": "does-not-exist",
+      },
+      body: JSON.stringify({ jsonrpc: "2.0", method: "tools/list", id: 1 }),
+    });
+    expect(res.status).toBe(404);
+  });
+
+  // THE bug PR #89 set out to fix: a single shared McpServer cannot back two
+  // transports, so the second client used to get "400 already initialized".
+  it("supports two concurrent clients, each with its own session", async () => {
+    const clientA = new Client({ name: "a", version: "1.0" }, { capabilities: {} });
+    const clientB = new Client({ name: "b", version: "1.0" }, { capabilities: {} });
+
+    await clientA.connect(new StreamableHTTPClientTransport(new URL(`${baseUrl}/mcp`)));
+    await clientB.connect(new StreamableHTTPClientTransport(new URL(`${baseUrl}/mcp`)));
+
+    const [a, b] = await Promise.all([clientA.listTools(), clientB.listTools()]);
+
+    expect(a.tools[0].name).toBe("ping");
+    expect(b.tools[0].name).toBe("ping");
+    expect(store.size).toBe(2);
+    expect(serversCreated).toBe(2);
+
+    await clientA.close();
+    await clientB.close();
+  });
+
+  it("reuses one session across sequential requests from the same client", async () => {
+    const client = new Client({ name: "a", version: "1.0" }, { capabilities: {} });
+    await client.connect(new StreamableHTTPClientTransport(new URL(`${baseUrl}/mcp`)));
+
+    await client.listTools();
+    await client.listTools();
+    await client.listTools();
+
+    expect(store.size).toBe(1);
+    expect(serversCreated).toBe(1);
+
+    await client.close();
+  });
+
+  it("rejects a new session with 503 once the session cap is reached", async () => {
+    const clients: Client[] = [];
+    for (let i = 0; i < 4; i++) {
+      const c = new Client({ name: `c${i}`, version: "1.0" }, { capabilities: {} });
+      await c.connect(new StreamableHTTPClientTransport(new URL(`${baseUrl}/mcp`)));
+      clients.push(c);
+    }
+    expect(store.size).toBe(4);
+
+    const res = await fetch(`${baseUrl}/mcp`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Accept: "application/json, text/event-stream" },
+      body: JSON.stringify({
+        jsonrpc: "2.0",
+        method: "initialize",
+        id: 1,
+        params: {
+          protocolVersion: "2025-06-18",
+          capabilities: {},
+          clientInfo: { name: "overflow", version: "1.0" },
+        },
+      }),
+    });
+
+    expect(res.status).toBe(503);
+
+    for (const c of clients) await c.close();
+  });
+});

--- a/src/__tests__/unified-server.test.ts
+++ b/src/__tests__/unified-server.test.ts
@@ -24,17 +24,17 @@ describe("Unified server — tool registration", () => {
     ...PLEX_MUTATIVE_TOOL_SCHEMAS,
   ];
 
-  it("registers exactly 45 tools without mutative ops", () => {
+  it("registers exactly 46 tools without mutative ops", () => {
     const names = allBaseSchemas.map((s) => s.name);
-    expect(names).toHaveLength(45);
+    expect(names).toHaveLength(46);
     // No duplicates
-    expect(new Set(names).size).toBe(45);
+    expect(new Set(names).size).toBe(46);
   });
 
-  it("registers exactly 54 tools with mutative ops", () => {
+  it("registers exactly 55 tools with mutative ops", () => {
     const names = allSchemasWithMutative.map((s) => s.name);
-    expect(names).toHaveLength(54);
-    expect(new Set(names).size).toBe(54);
+    expect(names).toHaveLength(55);
+    expect(new Set(names).size).toBe(55);
   });
 
   it("includes plex core tools", () => {

--- a/src/__tests__/unified-server.test.ts
+++ b/src/__tests__/unified-server.test.ts
@@ -45,6 +45,7 @@ describe("Unified server — tool registration", () => {
     expect(names).toContain("get_on_deck");
     expect(names).toContain("get_media_details");
     expect(names).toContain("get_watch_history");
+    expect(names).toContain("get_active_sessions");
   });
 
   it("includes plex extended analytics tools (regression guard)", () => {

--- a/src/plex-mcp-server.ts
+++ b/src/plex-mcp-server.ts
@@ -32,11 +32,10 @@ import { ARR_TOOL_SCHEMAS } from "./arr/tool-schemas.js";
 import { createArrToolRegistry } from "./arr/tool-registry.js";
 
 class UnifiedMCPServer {
-  private server: Server;
-
-  constructor() {
-    this.server = new Server(
-      { name: "plex-mcp-server", version: "1.1.0" },
+  // Exposed so transport.ts can call main() to get a fresh server per session.
+  static createServer() {
+    const server = new Server(
+      { name: "plex-mcp-server", version: "1.2.0" },
       { capabilities: { tools: {} } }
     );
 
@@ -52,14 +51,12 @@ class UnifiedMCPServer {
 
     const plexTools = new PlexTools(plexClient);
     const traktFunctions = new TraktMCPFunctions(plexClient);
-    const plexRegistry = createPlexToolRegistry(plexTools, {
-      traktFunctions,
-    });
+    const plexRegistry = createPlexToolRegistry(plexTools, { traktFunctions });
     const traktRegistry = createTraktToolRegistry(traktFunctions);
     const arrFunctions = new ArrMCPFunctions();
     const arrRegistry = createArrToolRegistry(arrFunctions);
 
-    this.server.setRequestHandler(ListToolsRequestSchema, async () => ({
+    server.setRequestHandler(ListToolsRequestSchema, async () => ({
       tools: [
         ...PLEX_TOOL_SCHEMAS,
         ...PLEX_MUTATIVE_TOOL_SCHEMAS,
@@ -68,10 +65,9 @@ class UnifiedMCPServer {
       ],
     }));
 
-    this.server.setRequestHandler(CallToolRequestSchema, async (request) => {
+    server.setRequestHandler(CallToolRequestSchema, async (request) => {
       const { name, arguments: args } = request.params;
       const a = (args ?? {}) as Record<string, unknown>;
-
       try {
         if (plexRegistry.has(name)) return await plexRegistry.handle(name, a);
         if (traktRegistry.has(name)) return await traktRegistry.handle(name, a);
@@ -82,10 +78,16 @@ class UnifiedMCPServer {
         throw new McpError(ErrorCode.InternalError, `Error executing ${name}: ${msg}`);
       }
     });
+
+    return server;
   }
 
   async run() {
-    await startServer(this.server, "Plex MCP server (unified)");
+    // Pass a factory so transport creates one server per session.
+    await startServer(
+      () => UnifiedMCPServer.createServer(),
+      "Plex MCP server (unified)"
+    );
   }
 }
 

--- a/src/plex-mcp-server.ts
+++ b/src/plex-mcp-server.ts
@@ -32,8 +32,13 @@ import { ARR_TOOL_SCHEMAS } from "./arr/tool-schemas.js";
 import { createArrToolRegistry } from "./arr/tool-registry.js";
 
 class UnifiedMCPServer {
-  // Exposed so transport.ts can call main() to get a fresh server per session.
-  static createServer() {
+  /**
+   * Build a fully wired Server instance.
+   *
+   * A factory rather than a constructor because HTTP transport needs one
+   * Server per session — a single instance cannot back concurrent clients.
+   */
+  static createServer(): Server {
     const server = new Server(
       { name: "plex-mcp-server", version: "1.2.0" },
       { capabilities: { tools: {} } }
@@ -51,7 +56,9 @@ class UnifiedMCPServer {
 
     const plexTools = new PlexTools(plexClient);
     const traktFunctions = new TraktMCPFunctions(plexClient);
-    const plexRegistry = createPlexToolRegistry(plexTools, { traktFunctions });
+    const plexRegistry = createPlexToolRegistry(plexTools, {
+      traktFunctions,
+    });
     const traktRegistry = createTraktToolRegistry(traktFunctions);
     const arrFunctions = new ArrMCPFunctions();
     const arrRegistry = createArrToolRegistry(arrFunctions);
@@ -68,6 +75,7 @@ class UnifiedMCPServer {
     server.setRequestHandler(CallToolRequestSchema, async (request) => {
       const { name, arguments: args } = request.params;
       const a = (args ?? {}) as Record<string, unknown>;
+
       try {
         if (plexRegistry.has(name)) return await plexRegistry.handle(name, a);
         if (traktRegistry.has(name)) return await traktRegistry.handle(name, a);
@@ -81,19 +89,10 @@ class UnifiedMCPServer {
 
     return server;
   }
-
-  async run() {
-    // Pass a factory so transport creates one server per session.
-    await startServer(
-      () => UnifiedMCPServer.createServer(),
-      "Plex MCP server (unified)"
-    );
-  }
 }
 
 export async function main() {
-  const server = new UnifiedMCPServer();
-  await server.run();
+  await startServer(() => UnifiedMCPServer.createServer(), "Plex MCP server (unified)");
 }
 
 main().catch((error) => {

--- a/src/plex/tool-registry.ts
+++ b/src/plex/tool-registry.ts
@@ -108,6 +108,8 @@ export function createPlexToolRegistry(tools: PlexTools, options: ToolRegistryOp
 
   registry.register("get_watchlist", () => tools.getWatchlist());
 
+  registry.register("get_active_sessions", () => tools.getActiveSessions());
+
   registry.register("get_recently_watched", (args) =>
     tools.getRecentlyWatched(
       (args.limit as number) || DEFAULT_LIMITS.recentlyWatched,

--- a/src/plex/tool-schemas.ts
+++ b/src/plex/tool-schemas.ts
@@ -107,6 +107,15 @@ const GET_MEDIA_DETAILS_SCHEMA = {
   },
 };
 
+const GET_ACTIVE_SESSIONS_SCHEMA = {
+  name: "get_active_sessions",
+  description: "Get currently active Plex sessions (what's playing now)",
+  inputSchema: {
+    type: "object" as const,
+    properties: {},
+  },
+};
+
 const GET_EDITABLE_FIELDS_SCHEMA = {
   name: "get_editable_fields",
   description: "Get editable fields and available tags for a media item",
@@ -456,6 +465,7 @@ export const PLEX_CORE_TOOL_SCHEMAS = [
   GET_WATCHLIST_SCHEMA,
   GET_RECENTLY_WATCHED_SCHEMA,
   GET_WATCH_HISTORY_SCHEMA,
+  GET_ACTIVE_SESSIONS_SCHEMA,
 ];
 
 const GET_RECOMMENDATIONS_SCHEMA = {

--- a/src/plex/tool-schemas.ts
+++ b/src/plex/tool-schemas.ts
@@ -109,7 +109,9 @@ const GET_MEDIA_DETAILS_SCHEMA = {
 
 const GET_ACTIVE_SESSIONS_SCHEMA = {
   name: "get_active_sessions",
-  description: "Get currently active Plex sessions (what's playing now)",
+  description:
+    "Get currently active Plex streams — who is watching what right now, " +
+    "including player state, session location, transcode decisions and media quality",
   inputSchema: {
     type: "object" as const,
     properties: {},

--- a/src/plex/tools.ts
+++ b/src/plex/tools.ts
@@ -443,6 +443,44 @@ export class PlexTools {
     });
   }
 
+  async getActiveSessions(): Promise<MCPResponse> {
+    const data = await this.client.makeRequest("/status/sessions");
+    const container = data as { MediaContainer?: { Metadata?: Record<string, unknown>[]; size?: number } };
+    const items = container.MediaContainer?.Metadata || [];
+
+    return jsonResponse({
+      activeSessions: items.map((item: Record<string, unknown>) => ({
+        ratingKey: item.ratingKey,
+        title: item.title,
+        type: item.type,
+        grandparentTitle: item.grandparentTitle,
+        parentTitle: item.parentTitle,
+        summary: (item.summary as string || '').slice(0, 200),
+        duration: item.duration,
+        viewOffset: item.viewOffset,
+        user: item.User ? (item.User as Record<string, unknown>).title : null,
+        player: item.Player ? {
+          title: (item.Player as Record<string, unknown>).title,
+          state: (item.Player as Record<string, unknown>).state,
+          platform: (item.Player as Record<string, unknown>).platform,
+        } : null,
+        session: item.Session ? {
+          location: (item.Session as Record<string, unknown>).location,
+        } : null,
+        transcode: item.TranscodeSession ? {
+          videoDecision: (item.TranscodeSession as Record<string, unknown>).videoDecision,
+          audioDecision: (item.TranscodeSession as Record<string, unknown>).audioDecision,
+        } : null,
+        media: item.Media ? {
+          videoResolution: (item.Media as Record<string, unknown>).videoResolution,
+          videoCodec: (item.Media as Record<string, unknown>).videoCodec,
+          audioCodec: (item.Media as Record<string, unknown>).audioCodec,
+        } : null,
+      })),
+      sessionCount: container.MediaContainer?.size || 0,
+    });
+  }
+
   async getMediaDetails(ratingKey: string): Promise<MCPResponse> {
     validatePlexId(ratingKey, "ratingKey");
     const data = await this.client.makeRequest(`/library/metadata/${ratingKey}`);

--- a/src/plex/tools.ts
+++ b/src/plex/tools.ts
@@ -445,39 +445,53 @@ export class PlexTools {
 
   async getActiveSessions(): Promise<MCPResponse> {
     const data = await this.client.makeRequest("/status/sessions");
-    const container = data as { MediaContainer?: { Metadata?: Record<string, unknown>[]; size?: number } };
-    const items = container.MediaContainer?.Metadata || [];
+    const container = data as { MediaContainer?: { Metadata?: Record<string, unknown>[] } };
+    const items = container.MediaContainer?.Metadata ?? [];
 
     return jsonResponse({
-      activeSessions: items.map((item: Record<string, unknown>) => ({
-        ratingKey: item.ratingKey,
-        title: item.title,
-        type: item.type,
-        grandparentTitle: item.grandparentTitle,
-        parentTitle: item.parentTitle,
-        summary: (item.summary as string || '').slice(0, 200),
-        duration: item.duration,
-        viewOffset: item.viewOffset,
-        user: item.User ? (item.User as Record<string, unknown>).title : null,
-        player: item.Player ? {
-          title: (item.Player as Record<string, unknown>).title,
-          state: (item.Player as Record<string, unknown>).state,
-          platform: (item.Player as Record<string, unknown>).platform,
-        } : null,
-        session: item.Session ? {
-          location: (item.Session as Record<string, unknown>).location,
-        } : null,
-        transcode: item.TranscodeSession ? {
-          videoDecision: (item.TranscodeSession as Record<string, unknown>).videoDecision,
-          audioDecision: (item.TranscodeSession as Record<string, unknown>).audioDecision,
-        } : null,
-        media: item.Media ? {
-          videoResolution: (item.Media as Record<string, unknown>).videoResolution,
-          videoCodec: (item.Media as Record<string, unknown>).videoCodec,
-          audioCodec: (item.Media as Record<string, unknown>).audioCodec,
-        } : null,
-      })),
-      sessionCount: container.MediaContainer?.size || 0,
+      activeSessions: items.map((item) => {
+        // Plex returns Media as a list (python-plexapi: "media (List<Media>)").
+        // The first entry describes the stream actually being played.
+        const media = (item.Media as Record<string, unknown>[] | undefined)?.[0];
+        const player = item.Player as Record<string, unknown> | undefined;
+        const session = item.Session as Record<string, unknown> | undefined;
+        const transcode = item.TranscodeSession as Record<string, unknown> | undefined;
+
+        return {
+          ratingKey: item.ratingKey,
+          sessionKey: item.sessionKey,
+          title: item.title,
+          type: item.type,
+          grandparentTitle: item.grandparentTitle,
+          parentTitle: item.parentTitle,
+          summary: item.summary
+            ? truncate(String(item.summary), SUMMARY_PREVIEW_LENGTH)
+            : undefined,
+          duration: item.duration,
+          viewOffset: item.viewOffset,
+          user: (item.User as Record<string, unknown> | undefined)?.title ?? null,
+          player: player
+            ? { title: player.title, state: player.state, platform: player.platform }
+            : null,
+          session: session ? { location: session.location } : null,
+          transcode: transcode
+            ? {
+                videoDecision: transcode.videoDecision,
+                audioDecision: transcode.audioDecision,
+              }
+            : null,
+          media: media
+            ? {
+                videoResolution: media.videoResolution,
+                videoCodec: media.videoCodec,
+                audioCodec: media.audioCodec,
+              }
+            : null,
+        };
+      }),
+      // Derived from what we actually return — MediaContainer.size can be
+      // stale or reflect paging rather than the sessions in this payload.
+      sessionCount: items.length,
     });
   }
 

--- a/src/shared/transport.ts
+++ b/src/shared/transport.ts
@@ -1,11 +1,15 @@
 /**
  * Shared transport factory for MCP servers.
  * Supports stdio (default) and HTTP transports via --transport flag.
+ *
+ * Multi-session HTTP mode: each client connection gets its own
+ * StreamableHTTPServerTransport instance + a dedicated McpServer instance,
+ * keyed by session ID. This allows concurrent multi-agent requests without
+ * "already initialized" errors.
  */
 
 import { randomUUID } from "node:crypto";
 import { createServer } from "node:http";
-import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 
@@ -44,26 +48,56 @@ function parseArgs(): { transport: TransportMode; port: number } {
   return { transport, port };
 }
 
-export async function startServer(server: Server, serverName: string): Promise<void> {
+// ── Per-session state ─────────────────────────────────────────────────────────
+// One transport + one McpServer instance per session, so each agent gets
+// its own initialized state and concurrent requests don't block each other.
+interface SessionState {
+  transport: StreamableHTTPServerTransport;
+  inactivityTimer: ReturnType<typeof setInterval>;
+}
+const sessions = new Map<string, SessionState>();
+
+// Session inactivity timeout — close a session after this many seconds of idle.
+// The inactivity timer resets on every request that uses the session.
+const SESSION_TIMEOUT_SECONDS = parseInt(
+  process.env.SESSION_TIMEOUT_SECONDS || "300", 10
+);
+
+function closeSession(sessionId: string): void {
+  const state = sessions.get(sessionId);
+  if (!state) return;
+
+  clearInterval(state.inactivityTimer);
+  sessions.delete(sessionId);
+
+  // Remove onclose handler BEFORE closing to prevent recursion.
+  state.transport.onclose = undefined;
+  state.transport.close().catch(() => {});
+
+  console.error(`Session ${sessionId} closed (total: ${sessions.size})`);
+}
+
+// Factory function — subclasses/replace this to create a custom McpServer
+// with different tools registered. By default, the caller passes `getServer`
+// into startServer so we can call it fresh for each new session.
+export async function startServer(
+  getServer: () => { connect(t: any): Promise<void> },
+  serverName: string,
+  _options?: { transport?: TransportMode; port?: number }
+): Promise<void> {
   const { transport, port } = parseArgs();
 
   if (transport === "stdio") {
+    // stdio: single shared server, single session — no session management needed.
     const stdioTransport = new StdioServerTransport();
+    const server = getServer();
     await server.connect(stdioTransport);
     console.error(`${serverName} running on stdio`);
     return;
   }
 
-  // Stateful HTTP transport — session ID tracks each client connection.
-  // enableJsonResponse allows clients that don't support SSE to get JSON responses.
-  const httpTransport = new StreamableHTTPServerTransport({
-    sessionIdGenerator: () => randomUUID(),
-    enableJsonResponse: true,
-  });
-
-  await server.connect(httpTransport);
-
-  const httpServer = createServer(async (req: import("node:http").IncomingMessage, res: import("node:http").ServerResponse) => {
+  // ── Multi-session HTTP ──────────────────────────────────────────────────────
+  const httpServer = createServer(async (req, res) => {
     const url = new URL(req.url || "/", `http://${req.headers.host || "localhost"}`);
 
     if (url.pathname === "/health" && req.method === "GET") {
@@ -72,16 +106,99 @@ export async function startServer(server: Server, serverName: string): Promise<v
       return;
     }
 
-    if (url.pathname === "/mcp") {
-      await httpTransport.handleRequest(req, res);
+    if (url.pathname !== "/mcp") {
+      res.writeHead(404, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({
+        error: "Not Found",
+        message: "Use POST /mcp for MCP requests, or GET /health for health check",
+      }));
       return;
     }
 
-    res.writeHead(404, { "Content-Type": "application/json" });
-    res.end(JSON.stringify({
-      error: "Not Found",
-      message: "Use POST /mcp for MCP requests, or GET /health for health check",
-    }));
+    // Read and parse the request body once.
+    const rawBody = await new Promise<string>((resolve, reject) => {
+      let data = "";
+      req.on("data", (chunk: any) => { data += chunk; });
+      req.on("end", () => resolve(data));
+      req.on("error", reject);
+    });
+
+    let body: unknown;
+    try {
+      body = JSON.parse(rawBody);
+    } catch {
+      res.writeHead(400, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ jsonrpc: "2.0", error: { code: -32700, message: "Parse error" }, id: null }));
+      return;
+    }
+
+    // mcp-session-id: undefined when absent, string when present.
+    const rawSessionId = req.headers["mcp-session-id"];
+    const sessionId = typeof rawSessionId === "string" ? rawSessionId : undefined;
+
+    if (!sessionId) {
+      // ── New session: create transport + server, store in map ─────────────
+      const transport = new StreamableHTTPServerTransport({
+        sessionIdGenerator: () => randomUUID(),
+        enableJsonResponse: true,
+      });
+
+      let lastActivity = Date.now();
+
+      const inactivityTimer = setInterval(() => {
+        const idle = (Date.now() - lastActivity) / 1000;
+        if (idle > SESSION_TIMEOUT_SECONDS) {
+          console.error(
+            `Session idle for ${Math.round(idle)}s (>${SESSION_TIMEOUT_SECONDS}s), closing`
+          );
+          closeSession(transport.sessionId!);
+        }
+      }, 30_000);
+
+      // Set up onclose to clean up the session map.
+      transport.onclose = () => {
+        const sid = transport.sessionId;
+        if (sid) closeSession(sid);
+      };
+
+      // IMPORTANT: Create a fresh McpServer instance for this session.
+      // The SDK example creates one server per session — do NOT share a single
+      // server instance across transports; the internal state is not designed
+      // for concurrent connections to the same server object.
+      const server = getServer();
+      await server.connect(transport);
+      await transport.handleRequest(req, res, body);
+
+      // Register the session AFTER handleRequest (when sessionId is set).
+      // Note: onsessioninitialized may not fire in JSON response mode, so we
+      // do it here explicitly. Subsequent requests from this client (which
+      // include the session ID from the response header) will find it.
+      if (transport.sessionId && !sessions.has(transport.sessionId)) {
+        sessions.set(transport.sessionId, { transport, inactivityTimer });
+        console.error(`Session ${transport.sessionId} initialized (total: ${sessions.size})`);
+      }
+
+      // Reset activity timer after handling.
+      lastActivity = Date.now();
+      return;
+    }
+
+    // ── Existing session: reuse its transport ────────────────────────────────
+    const state = sessions.get(sessionId);
+    if (!state) {
+      res.writeHead(404, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({
+        jsonrpc: "2.0",
+        error: { code: -32001, message: "Session not found or expired" },
+        id: null,
+      }));
+      return;
+    }
+
+    // Reset inactivity timer on each request.
+    // We store lastActivity on the transport object as a lightweight timer.
+    (state.transport as any)._lastActivity = Date.now();
+    await state.transport.handleRequest(req, res, body);
   });
 
   httpServer.listen(port, () => {

--- a/src/shared/transport.ts
+++ b/src/shared/transport.ts
@@ -3,17 +3,323 @@
  * Supports stdio (default) and HTTP transports via --transport flag.
  *
  * Multi-session HTTP mode: each client connection gets its own
- * StreamableHTTPServerTransport instance + a dedicated McpServer instance,
- * keyed by session ID. This allows concurrent multi-agent requests without
- * "already initialized" errors.
+ * StreamableHTTPServerTransport backed by its own Server instance, keyed by
+ * session ID. A single Server cannot back multiple transports — its
+ * initialization state is per-connection — so sharing one across clients makes
+ * the second client fail with "already initialized".
  */
 
 import { randomUUID } from "node:crypto";
-import { createServer } from "node:http";
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import { StreamableHTTPServerTransport } from "@modelcontextprotocol/sdk/server/streamableHttp.js";
 
 type TransportMode = "stdio" | "http";
+
+/** Largest accepted JSON-RPC request body. Guards against memory exhaustion
+ *  from an unauthenticated POST to /mcp. */
+export const DEFAULT_MAX_BODY_BYTES = 4 * 1024 * 1024;
+
+/** Close a session after this long with no traffic. */
+export const DEFAULT_SESSION_IDLE_MS = 300_000;
+
+/** Ceiling on concurrent sessions. Each session holds a Server instance, so
+ *  this bounds memory against a client that never reuses its session ID. */
+export const DEFAULT_MAX_SESSIONS = 64;
+
+/** How often the idle sweeper runs. */
+export const SESSION_SWEEP_INTERVAL_MS = 30_000;
+
+export class BodyTooLargeError extends Error {
+  constructor(limit: number) {
+    super(`Request body exceeds ${limit} bytes`);
+    this.name = "BodyTooLargeError";
+  }
+}
+
+export class SessionLimitError extends Error {
+  constructor(limit: number) {
+    super(`Maximum of ${limit} concurrent sessions reached`);
+    this.name = "SessionLimitError";
+  }
+}
+
+/**
+ * Read a request body, refusing anything over `maxBytes`.
+ *
+ * Length is tracked in bytes across chunks rather than trusting
+ * Content-Length, which a client controls and may understate.
+ */
+export function readBody(req: IncomingMessage, maxBytes: number): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const chunks: Buffer[] = [];
+    let total = 0;
+
+    req.on("data", (chunk: Buffer) => {
+      total += chunk.length;
+      if (total > maxBytes) {
+        // Pause rather than destroy: the caller still needs the socket open
+        // long enough to write a 413 the client can actually read.
+        req.pause();
+        reject(new BodyTooLargeError(maxBytes));
+        return;
+      }
+      chunks.push(chunk);
+    });
+    req.on("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
+    req.on("error", reject);
+  });
+}
+
+/** The subset of StreamableHTTPServerTransport the store depends on. */
+interface SessionTransport {
+  sessionId?: string;
+  close(): Promise<void>;
+  onclose?: (() => void) | undefined;
+}
+
+interface SessionEntry {
+  transport: SessionTransport;
+  lastActivity: number;
+}
+
+export interface SessionStoreOptions {
+  maxSessions?: number;
+  idleTimeoutMs?: number;
+  /** Injectable clock — keeps idle-expiry behaviour testable. */
+  now?: () => number;
+}
+
+/**
+ * Tracks live HTTP sessions and expires idle ones.
+ *
+ * A single sweeper timer scans the map rather than one timer per session:
+ * per-session timers leak whenever a session is dropped by a path that does
+ * not own its timer.
+ */
+export class SessionStore {
+  private readonly sessions = new Map<string, SessionEntry>();
+  private readonly maxSessions: number;
+  private readonly idleTimeoutMs: number;
+  private readonly now: () => number;
+  private sweeper?: ReturnType<typeof setInterval>;
+
+  constructor(options: SessionStoreOptions = {}) {
+    this.maxSessions = options.maxSessions ?? DEFAULT_MAX_SESSIONS;
+    this.idleTimeoutMs = options.idleTimeoutMs ?? DEFAULT_SESSION_IDLE_MS;
+    this.now = options.now ?? Date.now;
+  }
+
+  get size(): number {
+    return this.sessions.size;
+  }
+
+  isFull(): boolean {
+    return this.sessions.size >= this.maxSessions;
+  }
+
+  has(id: string): boolean {
+    return this.sessions.has(id);
+  }
+
+  /** Register a session. Throws SessionLimitError when at capacity. */
+  add(transport: SessionTransport): void {
+    const id = transport.sessionId;
+    if (!id) throw new Error("Cannot register a transport with no session ID");
+    if (!this.sessions.has(id) && this.isFull()) {
+      throw new SessionLimitError(this.maxSessions);
+    }
+    this.sessions.set(id, { transport, lastActivity: this.now() });
+  }
+
+  /** Look up a session, recording the lookup as activity. */
+  get(id: string): SessionTransport | undefined {
+    const entry = this.sessions.get(id);
+    if (!entry) return undefined;
+    entry.lastActivity = this.now();
+    return entry.transport;
+  }
+
+  close(id: string): void {
+    const entry = this.sessions.get(id);
+    if (!entry) return;
+
+    this.sessions.delete(id);
+    // Detach before closing: the transport's own close path fires onclose,
+    // which would otherwise re-enter here.
+    entry.transport.onclose = undefined;
+    void entry.transport.close().catch(() => {});
+  }
+
+  /** Close every session idle beyond the timeout. Returns the closed IDs. */
+  sweep(): string[] {
+    const deadline = this.now() - this.idleTimeoutMs;
+    const expired: string[] = [];
+
+    for (const [id, entry] of this.sessions) {
+      if (entry.lastActivity < deadline) expired.push(id);
+    }
+    for (const id of expired) this.close(id);
+
+    return expired;
+  }
+
+  closeAll(): void {
+    for (const id of [...this.sessions.keys()]) this.close(id);
+    this.stopSweeper();
+  }
+
+  startSweeper(intervalMs: number = SESSION_SWEEP_INTERVAL_MS): void {
+    if (this.sweeper) return;
+    this.sweeper = setInterval(() => {
+      for (const id of this.sweep()) {
+        console.error(`Session ${id} expired after ${this.idleTimeoutMs}ms idle`);
+      }
+    }, intervalMs);
+    // Do not hold the event loop open on this timer.
+    this.sweeper.unref?.();
+  }
+
+  stopSweeper(): void {
+    if (!this.sweeper) return;
+    clearInterval(this.sweeper);
+    this.sweeper = undefined;
+  }
+}
+
+function sendJson(res: ServerResponse, status: number, payload: unknown): void {
+  res.writeHead(status, { "Content-Type": "application/json" });
+  res.end(JSON.stringify(payload));
+}
+
+function sendRpcError(res: ServerResponse, status: number, code: number, message: string): void {
+  sendJson(res, status, { jsonrpc: "2.0", error: { code, message }, id: null });
+}
+
+export interface McpHandlerOptions {
+  /** Called once per new session to build a dedicated Server instance. */
+  getServer: () => Server;
+  serverName: string;
+  store: SessionStore;
+  maxBodyBytes?: number;
+}
+
+/**
+ * Build the node:http request handler for HTTP transport mode.
+ *
+ * Exposed separately from startServer so it can be exercised against an
+ * ephemeral port without going through argv parsing.
+ */
+export function createMcpRequestHandler(options: McpHandlerOptions) {
+  const { getServer, serverName, store } = options;
+  const maxBodyBytes = options.maxBodyBytes ?? DEFAULT_MAX_BODY_BYTES;
+
+  return async function handle(req: IncomingMessage, res: ServerResponse): Promise<void> {
+    const url = new URL(req.url || "/", `http://${req.headers.host || "localhost"}`);
+
+    if (url.pathname === "/health" && req.method === "GET") {
+      sendJson(res, 200, { status: "ok", server: serverName, sessions: store.size });
+      return;
+    }
+
+    if (url.pathname !== "/mcp") {
+      sendJson(res, 404, {
+        error: "Not Found",
+        message: "Use POST /mcp for MCP requests, or GET /health for health check",
+      });
+      return;
+    }
+
+    const rawSessionId = req.headers["mcp-session-id"];
+    const sessionId = typeof rawSessionId === "string" ? rawSessionId : undefined;
+
+    // GET (SSE stream) and DELETE (session teardown) carry no body and always
+    // belong to an existing session.
+    if (req.method !== "POST") {
+      if (!sessionId) {
+        sendRpcError(res, 400, -32000, "Missing mcp-session-id header");
+        return;
+      }
+      const transport = store.get(sessionId);
+      if (!transport) {
+        sendRpcError(res, 404, -32001, "Session not found or expired");
+        return;
+      }
+      await (transport as StreamableHTTPServerTransport).handleRequest(req, res);
+      return;
+    }
+
+    let rawBody: string;
+    try {
+      rawBody = await readBody(req, maxBodyBytes);
+    } catch (error) {
+      if (error instanceof BodyTooLargeError) {
+        // Close the connection once the 413 is flushed — we are deliberately
+        // not draining the rest of an oversized upload.
+        res.setHeader("Connection", "close");
+        res.once("finish", () => req.destroy());
+        sendRpcError(res, 413, -32600, error.message);
+        return;
+      }
+      sendRpcError(res, 400, -32600, "Failed to read request body");
+      return;
+    }
+
+    let body: unknown;
+    try {
+      body = JSON.parse(rawBody);
+    } catch {
+      sendRpcError(res, 400, -32700, "Parse error");
+      return;
+    }
+
+    // ── Existing session ──────────────────────────────────────────────────
+    if (sessionId) {
+      const transport = store.get(sessionId);
+      if (!transport) {
+        sendRpcError(res, 404, -32001, "Session not found or expired");
+        return;
+      }
+      await (transport as StreamableHTTPServerTransport).handleRequest(req, res, body);
+      return;
+    }
+
+    // ── New session ───────────────────────────────────────────────────────
+    if (store.isFull()) {
+      sendRpcError(res, 503, -32000, "Server at session capacity, try again later");
+      return;
+    }
+
+    const transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: () => randomUUID(),
+      enableJsonResponse: true,
+    });
+
+    transport.onclose = () => {
+      if (transport.sessionId) store.close(transport.sessionId);
+    };
+
+    // A dedicated Server per session — the whole point of the session map.
+    await getServer().connect(transport);
+    await transport.handleRequest(req, res, body);
+
+    // sessionId is only assigned once the initialize request has been handled.
+    if (transport.sessionId) {
+      try {
+        store.add(transport);
+        console.error(`Session ${transport.sessionId} initialized (total: ${store.size})`);
+      } catch (error) {
+        if (error instanceof SessionLimitError) {
+          transport.onclose = undefined;
+          void transport.close().catch(() => {});
+          return;
+        }
+        throw error;
+      }
+    }
+  };
+}
 
 function parseArgs(): { transport: TransportMode; port: number } {
   const args = process.argv.slice(2);
@@ -48,158 +354,47 @@ function parseArgs(): { transport: TransportMode; port: number } {
   return { transport, port };
 }
 
-// ── Per-session state ─────────────────────────────────────────────────────────
-// One transport + one McpServer instance per session, so each agent gets
-// its own initialized state and concurrent requests don't block each other.
-interface SessionState {
-  transport: StreamableHTTPServerTransport;
-  inactivityTimer: ReturnType<typeof setInterval>;
-}
-const sessions = new Map<string, SessionState>();
-
-// Session inactivity timeout — close a session after this many seconds of idle.
-// The inactivity timer resets on every request that uses the session.
-const SESSION_TIMEOUT_SECONDS = parseInt(
-  process.env.SESSION_TIMEOUT_SECONDS || "300", 10
-);
-
-function closeSession(sessionId: string): void {
-  const state = sessions.get(sessionId);
-  if (!state) return;
-
-  clearInterval(state.inactivityTimer);
-  sessions.delete(sessionId);
-
-  // Remove onclose handler BEFORE closing to prevent recursion.
-  state.transport.onclose = undefined;
-  state.transport.close().catch(() => {});
-
-  console.error(`Session ${sessionId} closed (total: ${sessions.size})`);
+function positiveIntFromEnv(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (!raw) return fallback;
+  const value = parseInt(raw, 10);
+  return Number.isFinite(value) && value > 0 ? value : fallback;
 }
 
-// Factory function — subclasses/replace this to create a custom McpServer
-// with different tools registered. By default, the caller passes `getServer`
-// into startServer so we can call it fresh for each new session.
+/**
+ * Start the server on the transport selected by argv.
+ *
+ * Takes a factory rather than an instance: HTTP mode needs a fresh Server per
+ * session, and only the caller knows how to build one.
+ */
 export async function startServer(
-  getServer: () => { connect(t: any): Promise<void> },
-  serverName: string,
-  _options?: { transport?: TransportMode; port?: number }
+  getServer: () => Server,
+  serverName: string
 ): Promise<void> {
   const { transport, port } = parseArgs();
 
   if (transport === "stdio") {
-    // stdio: single shared server, single session — no session management needed.
-    const stdioTransport = new StdioServerTransport();
-    const server = getServer();
-    await server.connect(stdioTransport);
+    // One process, one client, one session — no session tracking needed.
+    await getServer().connect(new StdioServerTransport());
     console.error(`${serverName} running on stdio`);
     return;
   }
 
-  // ── Multi-session HTTP ──────────────────────────────────────────────────────
-  const httpServer = createServer(async (req, res) => {
-    const url = new URL(req.url || "/", `http://${req.headers.host || "localhost"}`);
-
-    if (url.pathname === "/health" && req.method === "GET") {
-      res.writeHead(200, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({ status: "ok", server: serverName }));
-      return;
-    }
-
-    if (url.pathname !== "/mcp") {
-      res.writeHead(404, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({
-        error: "Not Found",
-        message: "Use POST /mcp for MCP requests, or GET /health for health check",
-      }));
-      return;
-    }
-
-    // Read and parse the request body once.
-    const rawBody = await new Promise<string>((resolve, reject) => {
-      let data = "";
-      req.on("data", (chunk: any) => { data += chunk; });
-      req.on("end", () => resolve(data));
-      req.on("error", reject);
-    });
-
-    let body: unknown;
-    try {
-      body = JSON.parse(rawBody);
-    } catch {
-      res.writeHead(400, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({ jsonrpc: "2.0", error: { code: -32700, message: "Parse error" }, id: null }));
-      return;
-    }
-
-    // mcp-session-id: undefined when absent, string when present.
-    const rawSessionId = req.headers["mcp-session-id"];
-    const sessionId = typeof rawSessionId === "string" ? rawSessionId : undefined;
-
-    if (!sessionId) {
-      // ── New session: create transport + server, store in map ─────────────
-      const transport = new StreamableHTTPServerTransport({
-        sessionIdGenerator: () => randomUUID(),
-        enableJsonResponse: true,
-      });
-
-      let lastActivity = Date.now();
-
-      const inactivityTimer = setInterval(() => {
-        const idle = (Date.now() - lastActivity) / 1000;
-        if (idle > SESSION_TIMEOUT_SECONDS) {
-          console.error(
-            `Session idle for ${Math.round(idle)}s (>${SESSION_TIMEOUT_SECONDS}s), closing`
-          );
-          closeSession(transport.sessionId!);
-        }
-      }, 30_000);
-
-      // Set up onclose to clean up the session map.
-      transport.onclose = () => {
-        const sid = transport.sessionId;
-        if (sid) closeSession(sid);
-      };
-
-      // IMPORTANT: Create a fresh McpServer instance for this session.
-      // The SDK example creates one server per session — do NOT share a single
-      // server instance across transports; the internal state is not designed
-      // for concurrent connections to the same server object.
-      const server = getServer();
-      await server.connect(transport);
-      await transport.handleRequest(req, res, body);
-
-      // Register the session AFTER handleRequest (when sessionId is set).
-      // Note: onsessioninitialized may not fire in JSON response mode, so we
-      // do it here explicitly. Subsequent requests from this client (which
-      // include the session ID from the response header) will find it.
-      if (transport.sessionId && !sessions.has(transport.sessionId)) {
-        sessions.set(transport.sessionId, { transport, inactivityTimer });
-        console.error(`Session ${transport.sessionId} initialized (total: ${sessions.size})`);
-      }
-
-      // Reset activity timer after handling.
-      lastActivity = Date.now();
-      return;
-    }
-
-    // ── Existing session: reuse its transport ────────────────────────────────
-    const state = sessions.get(sessionId);
-    if (!state) {
-      res.writeHead(404, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({
-        jsonrpc: "2.0",
-        error: { code: -32001, message: "Session not found or expired" },
-        id: null,
-      }));
-      return;
-    }
-
-    // Reset inactivity timer on each request.
-    // We store lastActivity on the transport object as a lightweight timer.
-    (state.transport as any)._lastActivity = Date.now();
-    await state.transport.handleRequest(req, res, body);
+  const store = new SessionStore({
+    maxSessions: positiveIntFromEnv("MCP_MAX_SESSIONS", DEFAULT_MAX_SESSIONS),
+    idleTimeoutMs:
+      positiveIntFromEnv("SESSION_TIMEOUT_SECONDS", DEFAULT_SESSION_IDLE_MS / 1000) * 1000,
   });
+  store.startSweeper();
+
+  const httpServer = createServer(createMcpRequestHandler({ getServer, serverName, store }));
+
+  const shutdown = () => {
+    store.closeAll();
+    httpServer.close(() => process.exit(0));
+  };
+  process.once("SIGINT", shutdown);
+  process.once("SIGTERM", shutdown);
 
   httpServer.listen(port, () => {
     console.error(`${serverName} running on http://localhost:${port}/mcp`);


### PR DESCRIPTION
Carries the four commits from #89 by @poedenon, with their authorship intact, plus hardening on top.

Supersedes #102 and #103 (earlier attempts of mine that squashed away the attribution).

## What's here

**@poedenon's work** — `get_active_sessions`, and the diagnosis that a single shared `Server` instance cannot back multiple HTTP transports, which is what made concurrent agents fail with `400 already initialized`. The diagnosis was correct and the per-session approach is the right fix.

**Hardening on top**, from defects found while adding test coverage:

| Defect | Effect |
|---|---|
| `Media` read as an object | Plex returns it as a list (python-plexapi: `media (List<Media>)`), so every media field resolved to `undefined` while the response still looked well-formed |
| `sessionCount` trusted `MediaContainer.size` | Stale or paging-affected; now derived from the sessions actually returned |
| Idle expiry never reset | Activity was written to `transport._lastActivity`, a field the expiry check never read — every session died 300s after creation regardless of traffic |
| Unbounded request body | An unauthenticated `POST /mcp` could exhaust memory; now capped at 4 MB with a `413` the client can read before the socket closes |
| Unbounded sessions, leaked timers | No ceiling on session creation, and per-session timers leaked when a session was dropped by a path that didn't own its timer; now capped (`503`) and swept by one unref'd timer |
| `GET`/`DELETE` routed through body parsing | `DELETE /mcp` now tears a session down and frees its slot |
| Dockerfile could not work | `build/` is gitignored so `COPY build/` failed, and `npm ci --only=production` omits typescript so the `npm run build` fallback failed silently behind `|| true` — producing an image with no compiled output |

## CI gaps this exposed

**Intermediate commits were never built.** A push of N commits fires one workflow run against the head SHA only, so every commit in between lands on `main` having never been compiled or tested — invisible until someone bisects onto one that can't build.

This wasn't hypothetical: all four inherited commits failed `npm test`, because adding a tool moved the inventory guard from 45 to 46 without updating it. Nobody saw it because **CI never ran on #89 at all** — fork PRs need workflow approval, so its only checks were Socket Security. The count update has been folded back into the commit that introduced the tool, so every commit here is green individually.

The new `per-commit` job walks the pushed/PR range and builds each non-merge commit. It's restricted to pushes and same-repo PRs so it doesn't multiply fork-code execution; fork commits are still covered by the push event on merge.

**The workflow token was persisted to disk.** `actions/checkout` writes `GITHUB_TOKEN` into `.git/config` and leaves it there, and every workflow then runs project code that could read it. All 13 checkout steps now set `persist-credentials: false`.

**Dependabot couldn't see the Dockerfile.** `npm audit` reads `package.json`, not the image, so a base-image CVE would go unnoticed. Added the `docker` ecosystem on the same weekly schedule.

## Verification

- All 8 commits build and test green **individually**, not just at head
- 226 tests across 14 files (was 199)
- TypeScript 7.0.2 clean
- Three concurrent clients against the real unified server — the original bug, gone
- `DELETE /mcp` reclaims a session (verified live: 1 → 0)
- Docker image builds, runs as non-root, serves `/health`; hadolint clean at the workflow's `failure-threshold: warning`

## Attribution

Adds `CONTRIBUTORS.md`, crediting @poedenon, @rolo20 and @punkpeye for work already merged. **Merge with a merge commit, not squash** — squashing would collapse @poedenon's four commits into one authored by me and remove him from the contributors graph.

Closes #89
