### PR TITLE
Squash Dependabot merges and document the release policy

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -19,9 +19,15 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
+      # Squash, not merge. A merge commit makes Release Please count the
+      # update twice — once from the PR title it associates with the merge
+      # commit, and once from the commit inside — so every dependency bump
+      # appears as a duplicate changelog line. Contributor PRs are still
+      # merged (not squashed) to preserve authorship on the contributors
+      # graph; Dependabot is a bot and has no authorship to preserve.
       - name: Auto-merge patch and minor updates
         if: steps.metadata.outputs.update-type != 'version-update:semver-major'
-        run: gh pr merge "$PR_URL" --auto --merge
+        run: gh pr merge "$PR_URL" --auto --squash
         env:
           PR_URL: ${{ github.event.pull_request.html_url }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -329,7 +329,7 @@ npm run dev
 
 Contributions are welcome! Please feel free to submit a Pull Request. For major changes, please open an issue first to discuss what you would like to change.
 
-Merged contributors are credited in [CONTRIBUTORS.md](CONTRIBUTORS.md).
+Merged contributors are credited in [CONTRIBUTORS.md](CONTRIBUTORS.md). Please use [Conventional Commits](https://www.conventionalcommits.org/) — releases and the changelog are generated from them, see [docs/RELEASING.md](docs/RELEASING.md).
 
 ### Development Guidelines
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This MCP server transforms your Plex Media Server into an AI-queryable database.
 
 ## Features
 
-**45 tools** out of the box (54 with write operations enabled):
+**46 tools** out of the box (55 with write operations enabled):
 
 - **Plex Library Management** — Browse libraries, search media, get detailed metadata, list playlists and watchlist
 - **Tautulli-Style Analytics** — Viewing statistics, user activity, popular content, watch history

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -1,0 +1,79 @@
+# Releasing
+
+Releases are automated. A release is **the act of merging the release PR** —
+there is nothing to cut by hand.
+
+## How it works
+
+1. Commits land on `main` using [Conventional Commits](https://www.conventionalcommits.org/).
+2. On every push to `main`, `.github/workflows/release.yml` runs Release Please,
+   which accumulates those commits into a release PR titled
+   `chore(main): release X.Y.Z`. That PR bumps `package.json`,
+   `package-lock.json` and `.release-please-manifest.json`, and regenerates
+   `CHANGELOG.md`.
+3. Merging the release PR creates the tag and the GitHub Release, then builds,
+   tests, audits and publishes to npm — all inside the same workflow run.
+
+Nothing reaches npm until you merge that PR, so the version and changelog are
+always reviewable first.
+
+### Why the publish is not in `publish.yml`
+
+A release created with `GITHUB_TOKEN` **does not trigger further workflow
+runs** — GitHub blocks that to prevent recursion. `publish.yml` fires on
+`release: published`, so it would never run for an automated release: you would
+get GitHub Releases that silently never reach npm, with every check green.
+
+So `release.yml` publishes inline. `publish.yml` remains for releases a human
+creates manually. The two cannot double-publish, precisely because of the rule
+above.
+
+## Merge strategy — this matters
+
+| PR source | Strategy | Why |
+|---|---|---|
+| Outside contributor | **Merge commit** | Preserves their commits' authorship. GitHub's contributors graph is built from the commit *author* field, so squashing erases them from it — and a `Co-authored-by` trailer does **not** put them back (verified: a co-author-only contributor does not appear in the contributors API). |
+| Dependabot | **Squash** (automated) | A bot has no authorship to preserve, and squashing avoids duplicate changelog entries. |
+| Your own branches | Either | Squash if the intermediate commits aren't interesting. |
+
+### Avoiding duplicate changelog entries
+
+Release Please reads **both** the commits inside a PR and the PR title it
+associates with the merge commit. So when a PR is merged with a merge commit
+and its title carries a Conventional Commit prefix, the change is counted
+twice.
+
+**When merging a contributor PR with a merge commit, give the PR a plain
+title** — `Add get_active_sessions and multi-session HTTP transport`, not
+`feat: add get_active_sessions ...`. The individual commits supply the
+changelog entries; the PR title should not compete with them.
+
+If a duplicate slips through, edit `CHANGELOG.md` directly on the release PR
+branch before merging.
+
+## Version bumping
+
+Release Please decides the bump from the commit types since the last release:
+
+| Commit | Bump |
+|---|---|
+| `fix:` | patch |
+| `feat:` | minor |
+| `feat!:` / `BREAKING CHANGE:` footer | major |
+| `docs:`, `build:` | patch (shown in changelog) |
+| `ci:`, `chore:`, `refactor:`, `test:` | no release |
+
+Dependabot is configured in `.github/dependabot.yml` to use these prefixes —
+`fix` for production dependencies (so a security bump ships a patch release),
+`chore` for dev dependencies, `ci` for actions, `build` for Docker base images.
+Without that, its default `Bump X from A to B` is not a Conventional Commit and
+Release Please ignores it entirely, meaning **security updates would never cut
+a release**.
+
+## Prerequisites (already configured)
+
+- Settings → Actions → General → **Allow GitHub Actions to create and approve
+  pull requests** must be on, or Release Please cannot open the release PR.
+- npm publishing uses OIDC trusted publishing — there is no npm token stored.
+- `.release-please-manifest.json` must track the currently published version,
+  or the first release will collide with an existing npm version and fail.

--- a/src/__tests__/docs-consistency.test.ts
+++ b/src/__tests__/docs-consistency.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { PLEX_TOOL_SCHEMAS, PLEX_MUTATIVE_TOOL_SCHEMAS } from "../plex/tool-schemas.js";
+import { TRAKT_TOOL_SCHEMAS } from "../trakt/tool-schemas.js";
+import { ARR_TOOL_SCHEMAS } from "../arr/tool-schemas.js";
+
+/**
+ * The README's tool counts have gone stale twice — once when a tool was added
+ * without updating the "Features" header, and again when only one of the two
+ * places stating the count was corrected. These assertions make the README a
+ * build-time obligation rather than something to remember.
+ */
+describe("README tool counts stay in sync with the schemas", () => {
+  const readme = readFileSync(new URL("../../README.md", import.meta.url), "utf8");
+
+  const plexCount = PLEX_TOOL_SCHEMAS.length;
+  const baseCount = plexCount + TRAKT_TOOL_SCHEMAS.length + ARR_TOOL_SCHEMAS.length;
+  const totalCount = baseCount + PLEX_MUTATIVE_TOOL_SCHEMAS.length;
+
+  it("states the Plex tool count correctly", () => {
+    expect(readme).toContain(`### Plex Tools (${plexCount} tools)`);
+  });
+
+  it("states the base and total counts in the Features section", () => {
+    expect(readme).toContain(
+      `**${baseCount} tools** out of the box (${totalCount} with write operations enabled)`
+    );
+  });
+
+  it("states the base and total counts above the tool tables", () => {
+    expect(readme).toContain(
+      `${baseCount} tools out of the box (${totalCount} with write operations enabled)`
+    );
+  });
+
+  it("never states a stale count anywhere", () => {
+    // Any "N tools out of the box" must be the real number.
+    const claims = [...readme.matchAll(/(\d+) tools\*{0,2} out of the box/g)].map((m) =>
+      Number(m[1])
+    );
+    expect(claims.length).toBeGreaterThan(0);
+    for (const claimed of claims) expect(claimed).toBe(baseCount);
+  });
+
+  it("documents every registered tool name in the README", () => {
+    const names = [
+      ...PLEX_TOOL_SCHEMAS,
+      ...PLEX_MUTATIVE_TOOL_SCHEMAS,
+      ...TRAKT_TOOL_SCHEMAS,
+      ...ARR_TOOL_SCHEMAS,
+    ].map((s) => s.name);
+
+    const undocumented = names.filter((n) => !readme.includes(`\`${n}\``));
+    expect(undocumented).toEqual([]);
+  });
+});


### PR DESCRIPTION
Fixes the duplicate changelog entries in release PR #109, at the root rather than by hand.

## The cause

Release Please reads **both** the commits inside a PR and the PR title it associates with the merge commit. A PR merged with a merge commit and a Conventional Commit title therefore counts twice — which is why 1.3.0's changelog lists the axios bump and the node bump twice each, and #104 both as its PR title and as its individual commits.

## The fix

**Dependabot auto-merge now squashes.** A bot has no authorship to preserve, so squashing costs nothing and eliminates the duplicates — which are the bulk of them.

**Contributor PRs must keep merge commits**, because GitHub's contributors graph is built from the commit *author* field and squashing erases an outside contributor from it. For those, the fix is a plain PR title (`Add get_active_sessions ...`) rather than a conventional one, so the merge commit doesn't compete with the commits inside it.

That distinction isn't discoverable from the config, so `docs/RELEASING.md` writes down the whole policy: merge strategy per PR source and why, the `GITHUB_TOKEN` recursion rule that forces the publish to live in `release.yml`, what each commit type bumps, and the repo settings the automation depends on.

Note this PR's own title is deliberately non-conventional, per the policy it documents.

## Also done outside this PR

`Per-commit build` and `Docker image` are now **required** status checks on `main` — previously they could fail without blocking a merge.