### PR TITLE
Correct which commit types actually bump the version

### DIFF
--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -68,15 +68,34 @@ Release Please decides the bump from the commit types since the last release:
 | `fix:` | patch |
 | `feat:` | minor |
 | `feat!:` / `BREAKING CHANGE:` footer | major |
-| `docs:`, `build:` | patch (shown in changelog) |
-| `ci:`, `chore:`, `refactor:`, `test:` | no release |
+| `docs:`, `build:` | **no bump** — appears in the changelog of the next release, but does not cause one |
+| `ci:`, `chore:`, `refactor:`, `test:` | no bump, hidden from the changelog |
 
-Dependabot is configured in `.github/dependabot.yml` to use these prefixes —
-`fix` for production dependencies (so a security bump ships a patch release),
-`chore` for dev dependencies, `ci` for actions, `build` for Docker base images.
-Without that, its default `Bump X from A to B` is not a Conventional Commit and
-Release Please ignores it entirely, meaning **security updates would never cut
-a release**.
+Only `feat`, `fix` and breaking changes move the version. `changelog-sections`
+in `release-please-config.json` controls **visibility only** — marking a type
+visible does not make it releasable. If the only commits since the last release
+are `docs`/`build`/`ci`/`chore`, no release PR is opened at all.
+
+Dependabot is configured in `.github/dependabot.yml` to use these prefixes.
+Without that, its default `Bump X from A to B` is not a Conventional Commit at
+all and Release Please ignores it entirely — meaning **security updates would
+never cut a release**.
+
+| Ecosystem | Prefix | Result | Why |
+|---|---|---|---|
+| npm, production | `fix` | **patch release** | Ships in the published package, so consumers need a version |
+| npm, development | `chore` | no release | Not in the published tarball |
+| github-actions | `ci` | no release | Affects the build, not the artefact |
+| docker | `build` | no release | The base image is not part of the npm package, and no image is published to a registry |
+
+Dependency updates should therefore only ever produce **patch** releases, never
+minor ones — a dependency bump does not change *this* package's public API. A
+minor bump means a `feat` landed.
+
+**Caveat on the Docker row:** if this project ever starts publishing a container
+image, a base-image CVE fix would need to ship, and `build` would have to become
+`fix`. As things stand nothing is published from the Dockerfile, so a bump there
+correctly releases nothing.
 
 ## Prerequisites (already configured)
 


### PR DESCRIPTION
Prompted by a good observation: dependency updates should be small bumps. They are — but the docs I wrote described the mechanism wrongly.

## The error

`RELEASING.md` said `docs:` and `build:` produce a patch release. They don't. **Only `feat`, `fix` and breaking changes bump the version.** `changelog-sections` controls visibility only — marking a type visible in the changelog does not make it releasable.

## Why it matters

Reading the old table, you'd conclude a Docker base-image bump (`build:`) ships a release. It doesn't — it produces no release at all.

That's actually **correct** here: the base image isn't part of the npm tarball and no container image is published anywhere, so there's nothing for consumers to receive. But the old wording was a quiet way to believe a base-image CVE fix had shipped when it hadn't. Now documented explicitly, with the caveat that `build` must become `fix` if this project ever publishes an image.

## What each ecosystem actually does

| Ecosystem | Prefix | Result |
|---|---|---|
| npm, production | `fix` | patch release |
| npm, development | `chore` | no release |
| github-actions | `ci` | no release |
| docker | `build` | no release |

So dependency updates only ever produce **patch** bumps — correct under semver, since a dependency change doesn't alter this package's public API. A minor bump means a `feat` landed, which is exactly what 1.3.0 is.