### PR TITLE
Publish from publish.yml only, so npm accepts the release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,17 +1,37 @@
 name: Publish to npm
 
-# Manual releases only. Automated releases are cut by release.yml, which
-# publishes inline — a release created with GITHUB_TOKEN does not trigger
-# workflows, so this one would never fire for them. That means the two cannot
-# double-publish: this runs for releases a human creates, release.yml for the
-# ones Release Please creates.
+# The only place that publishes to npm.
+#
+# npm's OIDC trusted publishing is bound to a specific workflow *filename*, not
+# just the repository — so publishing from anywhere else fails with a confusing
+# `E404 ... you do not have permission` even though the OIDC token is valid and
+# provenance signs successfully. Keeping every publish in this one file means
+# the trusted publisher config never has to change.
+#
+# Triggered two ways:
+#   - release: published  — a release a human cuts in the UI
+#   - workflow_dispatch   — release.yml calls this after Release Please cuts a
+#     release. It has to be a dispatch: a release created with GITHUB_TOKEN does
+#     not raise a `release` event that starts workflows (GitHub blocks that to
+#     prevent recursion), but workflow_dispatch is explicitly exempt.
 on:
   release:
     types: [published]
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to publish, e.g. v1.3.0"
+        required: true
+        type: string
 
 permissions:
   contents: read
   id-token: write
+
+# Never let two publishes of the same tag race.
+concurrency:
+  group: publish-${{ inputs.tag || github.ref }}
+  cancel-in-progress: false
 
 jobs:
   ci:
@@ -21,6 +41,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v7
         with:
+          ref: ${{ inputs.tag || github.ref }}
           persist-credentials: false
 
       - name: Setup Node.js
@@ -45,6 +66,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v7
         with:
+          ref: ${{ inputs.tag || github.ref }}
           persist-credentials: false
 
       - name: Setup Node.js
@@ -71,6 +93,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v7
         with:
+          ref: ${{ inputs.tag || github.ref }}
           persist-credentials: false
 
       - name: Setup Node.js
@@ -85,5 +108,22 @@ jobs:
       - name: Build
         run: npm run build
 
+      # Republishing an existing version is a hard error on npm, which would
+      # turn a harmless re-dispatch into a red build. Skip instead.
+      - name: Skip if this version is already on npm
+        id: check
+        run: |
+          set -euo pipefail
+          version=$(node -p "require('./package.json').version")
+          name=$(node -p "require('./package.json').name")
+          echo "publishing $name@$version"
+          if npm view "$name@$version" version >/dev/null 2>&1; then
+            echo "already=true" >> "$GITHUB_OUTPUT"
+            echo "::notice::$name@$version is already published — skipping."
+          else
+            echo "already=false" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Publish to npm
+        if: steps.check.outputs.already == 'false'
         run: npm publish --provenance --access public

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
     permissions:
       contents: write        # create tags and releases
       pull-requests: write   # maintain the release PR
-      id-token: write        # OIDC for npm trusted publishing
+      actions: write         # dispatch publish.yml
     steps:
       - name: Create or update the release PR, and release on merge
         id: release
@@ -28,41 +28,22 @@ jobs:
 
       # Everything below runs only on the push that merges the release PR.
       #
-      # The publish lives here rather than in publish.yml because a release
-      # created with GITHUB_TOKEN does not trigger further workflow runs —
-      # GitHub blocks that to prevent recursion. publish.yml would therefore
-      # never fire for an automated release. Doing it inline avoids needing a
-      # PAT, and keeps OIDC trusted publishing (no stored npm token).
-      - name: Checkout the released commit
+      # The publish is dispatched into publish.yml rather than done here,
+      # because npm's OIDC trusted publishing is bound to a specific workflow
+      # *filename*. Publishing from this file fails with
+      # `E404 ... you do not have permission` even though the OIDC token is
+      # valid and provenance signs fine — which is exactly how 1.3.0 ended up
+      # tagged and released on GitHub but absent from npm.
+      #
+      # workflow_dispatch is used because a release created with GITHUB_TOKEN
+      # does not raise a `release` event that starts workflows, but dispatches
+      # are explicitly exempt from that rule.
+      - name: Publish the release via publish.yml
         if: ${{ steps.release.outputs.release_created }}
-        uses: actions/checkout@v7
-        with:
-          persist-credentials: false
-
-      - name: Setup Node.js
-        if: ${{ steps.release.outputs.release_created }}
-        uses: actions/setup-node@v7
-        with:
-          node-version: "24"
-          registry-url: "https://registry.npmjs.org"
-          cache: npm
-
-      - name: Install dependencies
-        if: ${{ steps.release.outputs.release_created }}
-        run: npm ci
-
-      - name: Build
-        if: ${{ steps.release.outputs.release_created }}
-        run: npm run build
-
-      - name: Test
-        if: ${{ steps.release.outputs.release_created }}
-        run: npm test
-
-      - name: Audit
-        if: ${{ steps.release.outputs.release_created }}
-        run: npm audit --audit-level=moderate
-
-      - name: Publish to npm
-        if: ${{ steps.release.outputs.release_created }}
-        run: npm publish --provenance --access public
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ steps.release.outputs.tag_name }}
+        run: |
+          set -euo pipefail
+          echo "Dispatching publish.yml for $TAG"
+          gh workflow run publish.yml --repo "$GITHUB_REPOSITORY" --ref main -f tag="$TAG"

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -17,16 +17,28 @@ there is nothing to cut by hand.
 Nothing reaches npm until you merge that PR, so the version and changelog are
 always reviewable first.
 
-### Why the publish is not in `publish.yml`
+### How the publish actually happens
 
-A release created with `GITHUB_TOKEN` **does not trigger further workflow
-runs** — GitHub blocks that to prevent recursion. `publish.yml` fires on
-`release: published`, so it would never run for an automated release: you would
-get GitHub Releases that silently never reach npm, with every check green.
+`publish.yml` is the **only** workflow that publishes to npm. That is not
+stylistic: npm's OIDC trusted publishing is bound to a specific workflow
+*filename*, so publishing from any other file is rejected with
+`E404 ... you do not have permission` — even though the OIDC token is valid and
+the provenance statement signs successfully. The 404 (rather than a 403) makes
+it read like a missing package.
 
-So `release.yml` publishes inline. `publish.yml` remains for releases a human
-creates manually. The two cannot double-publish, precisely because of the rule
-above.
+This bit for real: 1.3.0 was published from `release.yml`, got tagged and
+released on GitHub, and never reached npm.
+
+So `release.yml` **dispatches** `publish.yml` instead of publishing itself. It
+has to be a dispatch rather than relying on the `release: published` event,
+because a release created with `GITHUB_TOKEN` does not raise an event that
+starts workflows — but `workflow_dispatch` is explicitly exempt from that rule.
+
+`publish.yml` skips the publish if the version is already on npm, so a repeated
+dispatch is harmless rather than a hard error.
+
+**If you ever move the publish to a different workflow file, update the trusted
+publisher on npmjs.com to match, or releases will silently stop reaching npm.**
 
 ## Merge strategy — this matters
 


### PR DESCRIPTION
1.3.0 is tagged and released on GitHub but **never reached npm**. This fixes the cause and makes the recovery repeatable.

## What happened

The publish ran from `release.yml` and npm rejected it:

```
npm notice publish Signed provenance statement with source and build information from GitHub Actions
npm error code E404
npm error 404 Not Found - PUT https://registry.npmjs.org/plex-mcp-server
npm error 404  ... could not be found or you do not have permission to access it.
```

Note the OIDC token was valid and provenance signed *successfully* — then the upload was refused.

**npm's OIDC trusted publishing is bound to a specific workflow filename**, not just the repository. The trusted publisher is registered against `publish.yml`, so a publish from `release.yml` is an unauthorised caller. npm returns 404 rather than 403 so it doesn't leak whether a package exists, which makes a permissions problem read like a missing package.

## The fix

`release.yml` now **dispatches** `publish.yml` instead of publishing inline, so every publish comes from the one file npm trusts.

It has to be `workflow_dispatch` rather than the `release: published` event, because a release created with `GITHUB_TOKEN` doesn't raise an event that starts workflows — but dispatches are explicitly exempt from that rule. (Same rule that caused the original problem, used deliberately this time.)

Also in `publish.yml`:
- optional `tag` input, checked out in all three jobs, so a dispatched publish builds the **released commit** rather than whatever `main` is now
- skips the publish if the version is already on npm — a repeated dispatch becomes a no-op instead of a red build
- a concurrency group so two publishes of the same tag can't race

## Alternative considered

Adding `release.yml` as a second trusted publisher on npmjs.com would also work, but needs a manual change in npm's UI and leaves two files that can publish. One publishing path is easier to reason about.

## After this merges

I'll dispatch `publish.yml` for `v1.3.0` to get the release onto npm, and confirm `npm view plex-mcp-server version` reports 1.3.0.