### PR TITLE
Dispatch the publish from the tag so provenance names the right commit

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,4 +46,10 @@ jobs:
         run: |
           set -euo pipefail
           echo "Dispatching publish.yml for $TAG"
-          gh workflow run publish.yml --repo "$GITHUB_REPOSITORY" --ref main -f tag="$TAG"
+          # Dispatch against the TAG, not main. GitHub's OIDC claims describe
+          # the ref the workflow was taken from, and those claims become the
+          # SLSA provenance. Dispatching from main makes the published package
+          # attest `refs/heads/main` at whatever commit main happens to be,
+          # even though the job checks out the tag — so the signature names a
+          # different source commit than the artifact was built from.
+          gh workflow run publish.yml --repo "$GITHUB_REPOSITORY" --ref "$TAG" -f tag="$TAG"

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -37,6 +37,20 @@ starts workflows — but `workflow_dispatch` is explicitly exempt from that rule
 `publish.yml` skips the publish if the version is already on npm, so a repeated
 dispatch is harmless rather than a hard error.
 
+### Provenance names the ref you dispatch from
+
+The dispatch targets the **tag**, not `main`. GitHub's OIDC claims describe the
+ref the workflow was taken from, and those claims become the SLSA provenance
+attached to the npm package. Dispatching from `main` makes the package attest
+`refs/heads/main` at whatever commit `main` happens to be — even though the job
+checks out the tag — so the signature names a different source commit than the
+artifact was actually built from.
+
+1.3.0 shipped with exactly that flaw: its provenance records
+`refs/heads/main@5314758` while the tag is `5deacd4`. Fixed from 1.3.1 onward.
+Because the dispatch now targets the tag, the tag must contain a `publish.yml`
+with a `workflow_dispatch` trigger — true for every tag cut after that change.
+
 **If you ever move the publish to a different workflow file, update the trusted
 publisher on npmjs.com to match, or releases will silently stop reaching npm.**
 


### PR DESCRIPTION
1.3.0's npm provenance attests the **wrong source commit**.

```
resolvedDependency: git+https://github.com/niavasha/plex-mcp-server@refs/heads/main
                    gitCommit: 5314758...
```

But `v1.3.0` is `5deacd4`. The tarball *was* built from the tag — `publish.yml` checks out the `tag` input — yet the signature says `main`.

## Cause

The dispatch used `--ref main`. GitHub's OIDC claims describe the ref the **workflow file** was taken from, not what the job subsequently checks out, and those claims become the SLSA provenance. So the package points at a source commit it wasn't built from, which defeats the point of provenance for anyone verifying the artifact against the tag.

## Fix

Dispatch against the tag. The claims then match what was built.

This requires the tag to contain a `publish.yml` with a `workflow_dispatch` trigger — true for every tag cut after this merges. (It's why 1.3.0 couldn't be re-published correctly: that tag predates the trigger.)

## Scope

1.3.0 keeps its inaccurate provenance; it can't be re-signed without unpublishing. The package contents are correct and the attestation is genuine — it just names `main@5314758` rather than the tag. Documented in `docs/RELEASING.md` so it isn't mistaken for tampering later.