### PR TITLE
Let a RELEASE_TOKEN secret unblock the release PR

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,8 +29,20 @@ permissions:
   id-token: write
 
 # Never let two publishes of the same tag race.
+#
+# The group must reduce to the same string for both triggers. Once release.yml
+# runs under RELEASE_TOKEN, the GitHub Release is created by a real identity,
+# so it *does* raise `release: published` — and this workflow is then started
+# twice for one version: once by that event and once by release.yml's dispatch.
+# `github.ref` would key those as `refs/tags/v1.4.0` vs the dispatch input
+# `v1.4.0`, i.e. two different groups that never serialise against each other.
+# `github.ref_name` drops the `refs/tags/` prefix so all three agree.
+#
+# The "already on npm" check below is the second line of defence, but on its
+# own it is racy: two concurrent runs can both observe "not published" before
+# either uploads.
 concurrency:
-  group: publish-${{ inputs.tag || github.ref }}
+  group: publish-${{ inputs.tag || github.ref_name }}
   cancel-in-progress: false
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,27 @@ jobs:
       - name: Create or update the release PR, and release on merge
         id: release
         uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5.0.0
+        with:
+          # Prefer RELEASE_TOKEN when it exists, else fall back to GITHUB_TOKEN.
+          #
+          # A release PR opened by GITHUB_TOKEN is authored by
+          # `github-actions[bot]`, and every workflow run on such a PR is held
+          # at `action_required` with 0s duration — created but never started.
+          # Branch protection then sees the required checks as missing and
+          # reports the PR as BLOCKED, which is indistinguishable from "checks
+          # still pending". 1.3.1 sat unreleased for a day that way, and 1.4.0
+          # did the same.
+          #
+          # Verified 2026-07-31 over 100 PR runs: github-actions[bot] had 16
+          # runs at action_required, dependabot[bot] had 0 — so this is
+          # specific to the GITHUB_TOKEN actor, not a fork or contributor
+          # policy. A PR opened under any other identity is not gated.
+          #
+          # RELEASE_TOKEN may be either a fine-grained PAT or a GitHub App
+          # installation token; both need contents:write + pull_requests:write.
+          # Unset is safe: releases still work, they just need each run
+          # approving by hand.
+          token: ${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
 
       # Everything below runs only on the push that merges the release PR.
       #

--- a/docs/RELEASING.md
+++ b/docs/RELEASING.md
@@ -123,6 +123,45 @@ image, a base-image CVE fix would need to ship, and `build` would have to become
 `fix`. As things stand nothing is published from the Dockerfile, so a bump there
 correctly releases nothing.
 
+### Why the release PR needs approving by hand
+
+Without a `RELEASE_TOKEN` secret, Release Please opens the release PR as
+`github-actions[bot]`. Every workflow run on such a PR is held at
+`action_required` with **0s duration** — created but never started. Branch
+protection then sees the required checks as missing and reports the PR as
+`BLOCKED`, which looks exactly like "checks are still pending".
+
+This is not a fork or outside-contributor policy. Measured across 100 PR runs
+on 2026-07-31: `github-actions[bot]` had 16 runs sitting at `action_required`,
+`dependabot[bot]` had **zero**. Dependabot is exempt; the `GITHUB_TOKEN` actor
+is not. 1.3.1 sat unreleased for a day this way, and 1.4.0 did the same.
+
+There is no PR-level approve. Approve each queued run by id:
+
+```bash
+gh run list --branch 'release-please--branches--main--components--plex-mcp-server' \
+  --json databaseId,conclusion,name \
+  --jq '.[] | select(.conclusion=="action_required") | "\(.databaseId) \(.name)"'
+
+gh api -X POST /repos/niavasha/plex-mcp-server/actions/runs/<run_id>/approve
+```
+
+Approving spawns *fresh* runs; the original `action_required` records stay
+frozen, so the run list shows both.
+
+**To stop this happening**, add a `RELEASE_TOKEN` repository secret —
+either a fine-grained PAT or a GitHub App installation token, with
+`contents: write` and `pull_requests: write`. `release.yml` already prefers it
+and falls back to `GITHUB_TOKEN`, so the secret is the only step; nothing
+breaks while it is absent.
+
+Note that once `RELEASE_TOKEN` is set, the GitHub Release is created by a real
+identity and therefore *does* raise `release: published`. `publish.yml` is then
+started twice for one version — once by that event, once by release.yml's
+dispatch. Both collapse into the same concurrency group (`github.ref_name`
+normalises `refs/tags/v1.4.0` to `v1.4.0`, matching the dispatch input), so
+they serialise and the second run skips on "already on npm".
+
 ## Prerequisites (already configured)
 
 - Settings → Actions → General → **Allow GitHub Actions to create and approve


### PR DESCRIPTION
Every release so far has needed each workflow run approving by hand. This makes that fixable with one secret.

## The gate

Release Please opens the release PR as `github-actions[bot]`, and runs on such a PR sit at `action_required` with **0s duration** — created but never started. Branch protection then reports `BLOCKED`, which looks exactly like "checks still pending". 1.3.1 sat unreleased for a day; 1.4.0 repeated it.

Measured across 100 PR runs:

| actor | action_required |
|---|---|
| `github-actions[bot]` | 16 |
| `dependabot[bot]` | **0** |

So it is specific to the `GITHUB_TOKEN` actor — not a fork or outside-contributor policy, both of which would have gated Dependabot too. A PR opened under any other identity is not gated.

## The change

`release.yml` now uses `${{ secrets.RELEASE_TOKEN || secrets.GITHUB_TOKEN }}`. Adding the secret is the only remaining step, and **nothing breaks while it is absent** — releases keep working exactly as today.

Either a fine-grained PAT or a GitHub App installation token works; both need `contents: write` + `pull_requests: write`.

## Plus a race that the secret would otherwise expose

Once a real identity creates the GitHub Release, `release: published` *does* fire — so `publish.yml` gets started twice for one version, once by that event and once by release.yml’s dispatch.

The concurrency group keyed those as `refs/tags/v1.4.0` (event) vs `v1.4.0` (dispatch) — two different groups, which never serialise against each other. That left only the "already on npm" check to arbitrate, and it is itself racy: both runs can observe "not published" before either uploads.

`github.ref_name` normalises all three triggers to the same string, so they serialise properly and the loser skips.

## Testing

`npm test` 243/243. Both workflow files parse. No `${{ }}` interpolation inside any `run:` block — all of it is in `env:`/`with:`/`if:`.

Cannot be end-to-end tested until the secret exists; the fallback path is what runs today and is unchanged.