### PR TITLE
fix: route account Watchlist through Plex Discover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Fixed
+
+- Route Universal Watchlist reads and mutations through Plex Discover using global Plex GUIDs instead of unsupported local Plex Media Server endpoints.
+
 ## [1.4.1](https://github.com/niavasha/plex-mcp-server/compare/v1.4.0...v1.4.1) (2026-08-08)
 
 

--- a/README.md
+++ b/README.md
@@ -171,7 +171,7 @@ Once configured, you can ask your AI assistant:
 | `get_editable_fields` | Show editable fields and available tags for an item |
 | `get_playlists` | List all Plex playlists |
 | `get_playlist_items` | List items in a playlist |
-| `get_watchlist` | Get current Plex watchlist |
+| `get_watchlist` | Get the current account Watchlist from Plex Discover |
 | `get_recently_watched` | Recently watched content |
 | `get_watch_history` | Detailed watch sessions |
 | `get_fully_watched` | Fully watched movies/shows |
@@ -195,8 +195,8 @@ Set `PLEX_ENABLE_MUTATIVE_OPS=true` to enable these tools. They allow your AI as
 | `remove_from_playlist` | Remove an item from a playlist |
 | `clear_playlist` | Preview and optionally clear all items from a playlist (`confirm=true`) |
 | `delete_playlist` | Delete a playlist without deleting the underlying media |
-| `add_to_watchlist` | Add a media item to the Plex watchlist |
-| `remove_from_watchlist` | Remove a media item from the Plex watchlist |
+| `add_to_watchlist` | Add a matched local movie or show to the account Watchlist |
+| `remove_from_watchlist` | Remove an account Watchlist item by its global Plex GUID or local rating key |
 
 ### Sonarr Tools (8 tools)
 

--- a/src/__tests__/plex-cloud-client.test.ts
+++ b/src/__tests__/plex-cloud-client.test.ts
@@ -1,0 +1,41 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import axios from "axios";
+import { PlexClient } from "../plex/client.js";
+
+vi.mock("axios", () => ({ default: vi.fn() }));
+
+describe("PlexClient Discover requests", () => {
+  const request = vi.mocked(axios);
+
+  beforeEach(() => {
+    request.mockReset();
+    request.mockResolvedValue({ data: { ok: true } });
+  });
+
+  it("sends account actions to Plex Discover with account authentication", async () => {
+    const client = new PlexClient({
+      baseUrl: "http://plex.local:32400/",
+      token: "secret-token",
+      clientIdentifier: "plex-mcp-test",
+    });
+
+    await client.makeDiscoverRequest(
+      "/actions/addToWatchlist",
+      { ratingKey: "abc123" },
+      "PUT"
+    );
+
+    expect(request).toHaveBeenCalledWith(
+      "https://discover.provider.plex.tv/actions/addToWatchlist",
+      expect.objectContaining({
+        method: "PUT",
+        params: { ratingKey: "abc123" },
+        headers: expect.objectContaining({
+          "X-Plex-Token": "secret-token",
+          "X-Plex-Client-Identifier": "plex-mcp-test",
+          "X-Plex-Product": "plex-mcp-server",
+        }),
+      })
+    );
+  });
+});

--- a/src/__tests__/plex-tools.test.ts
+++ b/src/__tests__/plex-tools.test.ts
@@ -7,6 +7,7 @@ import { SUMMARY_PREVIEW_LENGTH, DEFAULT_LIMITS } from "../plex/constants.js";
 function createMockClient() {
   return {
     makeRequest: vi.fn(),
+    makeDiscoverRequest: vi.fn(),
     getPlexTypeId: vi.fn((type: string) => {
       const ids: Record<string, number> = { movie: 1, show: 2, episode: 4 };
       return ids[type] || 1;
@@ -151,17 +152,122 @@ describe("PlexTools", () => {
   });
 
   describe("getWatchlist", () => {
-    it("truncates summaries", async () => {
-      (client.makeRequest as ReturnType<typeof vi.fn>).mockResolvedValue({
+    it("reads the account watchlist from Discover and exposes its global GUID", async () => {
+      (client.makeDiscoverRequest as ReturnType<typeof vi.fn>).mockResolvedValue({
         MediaContainer: {
           Metadata: [
-            { ratingKey: "1", title: "Watchlist Item", type: "movie", year: 2024, summary: LONG_SUMMARY, addedAt: 1000 },
+            {
+              ratingKey: "global-1",
+              guid: "plex://movie/global-1",
+              title: "Watchlist Item",
+              type: "movie",
+              year: 2024,
+              summary: LONG_SUMMARY,
+              watchlistedAt: 1000,
+            },
           ],
         },
       });
 
       const result = parseResponse(await tools.getWatchlist());
       expect(result.watchlist[0].summary.length).toBeLessThanOrEqual(SUMMARY_PREVIEW_LENGTH + 3);
+      expect(result.watchlist[0]).toMatchObject({
+        ratingKey: "global-1",
+        guid: "plex://movie/global-1",
+        addedAt: 1000,
+      });
+      expect(client.makeDiscoverRequest).toHaveBeenCalledWith(
+        "/library/sections/watchlist/all",
+        { includeCollections: 1, includeExternalMedia: 1 },
+        "GET"
+      );
+      expect(client.makeRequest).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("watchlist mutations", () => {
+    const ORIGINAL_MUTATIVE_ENV = process.env.PLEX_ENABLE_MUTATIVE_OPS;
+
+    beforeEach(() => {
+      process.env.PLEX_ENABLE_MUTATIVE_OPS = "true";
+    });
+
+    afterEach(() => {
+      if (ORIGINAL_MUTATIVE_ENV === undefined) {
+        delete process.env.PLEX_ENABLE_MUTATIVE_OPS;
+      } else {
+        process.env.PLEX_ENABLE_MUTATIVE_OPS = ORIGINAL_MUTATIVE_ENV;
+      }
+    });
+
+    it("adds a local item through Discover using its Plex GUID suffix", async () => {
+      (client.makeRequest as ReturnType<typeof vi.fn>).mockResolvedValue({
+        MediaContainer: { Metadata: [{ guid: "plex://movie/abc123" }] },
+      });
+      (client.makeDiscoverRequest as ReturnType<typeof vi.fn>).mockResolvedValue({});
+
+      const result = parseResponse(await tools.addToWatchlist("42"));
+
+      expect(client.makeDiscoverRequest).toHaveBeenCalledWith(
+        "/actions/addToWatchlist",
+        { ratingKey: "abc123" },
+        "PUT"
+      );
+      expect(result).toMatchObject({ updated: true, ratingKey: "42", plexGuid: "plex://movie/abc123" });
+    });
+
+    it("removes an account watchlist item directly by global Plex GUID", async () => {
+      (client.makeDiscoverRequest as ReturnType<typeof vi.fn>).mockResolvedValue({});
+
+      const result = parseResponse(
+        await tools.removeFromWatchlist({ plexGuid: "plex://show/show123" })
+      );
+
+      expect(client.makeDiscoverRequest).toHaveBeenCalledWith(
+        "/actions/removeFromWatchlist",
+        { ratingKey: "show123" },
+        "PUT"
+      );
+      expect(client.makeRequest).not.toHaveBeenCalled();
+      expect(result).toMatchObject({ updated: true, plexGuid: "plex://show/show123" });
+    });
+
+    it("keeps local rating keys as a compatibility path for removal", async () => {
+      (client.makeRequest as ReturnType<typeof vi.fn>).mockResolvedValue({
+        MediaContainer: { Metadata: [{ guid: "plex://movie/abc123" }] },
+      });
+      (client.makeDiscoverRequest as ReturnType<typeof vi.fn>).mockResolvedValue({});
+
+      await tools.removeFromWatchlist({ ratingKey: "42" });
+
+      expect(client.makeRequest).toHaveBeenCalledWith("/library/metadata/42");
+      expect(client.makeDiscoverRequest).toHaveBeenCalledWith(
+        "/actions/removeFromWatchlist",
+        { ratingKey: "abc123" },
+        "PUT"
+      );
+    });
+
+    it("keeps the legacy direct string argument for library consumers", async () => {
+      (client.makeRequest as ReturnType<typeof vi.fn>).mockResolvedValue({
+        MediaContainer: { Metadata: [{ guid: "plex://movie/legacy123" }] },
+      });
+      (client.makeDiscoverRequest as ReturnType<typeof vi.fn>).mockResolvedValue({});
+
+      await tools.removeFromWatchlist("42");
+
+      expect(client.makeDiscoverRequest).toHaveBeenCalledWith(
+        "/actions/removeFromWatchlist",
+        { ratingKey: "legacy123" },
+        "PUT"
+      );
+    });
+
+    it("rejects legacy or malformed global GUIDs before calling Discover", async () => {
+      await expect(
+        tools.removeFromWatchlist({ plexGuid: "imdb://tt1234567" })
+      ).rejects.toThrow(/Plex Movie or Plex TV Series agent/i);
+      expect(client.makeDiscoverRequest).not.toHaveBeenCalled();
     });
   });
 

--- a/src/__tests__/unified-server.test.ts
+++ b/src/__tests__/unified-server.test.ts
@@ -142,6 +142,28 @@ describe("Unified server — dispatch routing", () => {
     expect(plexRegistry.has("update_metadata")).toBe(true);
   });
 
+  it("passes either global GUIDs or local rating keys to watchlist removal", async () => {
+    const originalMutative = process.env.PLEX_ENABLE_MUTATIVE_OPS;
+    process.env.PLEX_ENABLE_MUTATIVE_OPS = "true";
+    const remove = vi
+      .spyOn(PlexTools.prototype, "removeFromWatchlist")
+      .mockResolvedValue({ content: [{ type: "text", text: "{}" }] });
+
+    try {
+      await plexRegistry.handle("remove_from_watchlist", {
+        plexGuid: "plex://movie/global123",
+      });
+      expect(remove).toHaveBeenCalledWith({
+        plexGuid: "plex://movie/global123",
+        ratingKey: undefined,
+      });
+    } finally {
+      remove.mockRestore();
+      if (originalMutative === undefined) delete process.env.PLEX_ENABLE_MUTATIVE_OPS;
+      else process.env.PLEX_ENABLE_MUTATIVE_OPS = originalMutative;
+    }
+  });
+
   it("trakt registry owns trakt tools", () => {
     expect(traktRegistry.has("trakt_authenticate")).toBe(true);
     expect(traktRegistry.has("trakt_search")).toBe(true);

--- a/src/plex/client.ts
+++ b/src/plex/client.ts
@@ -11,10 +11,16 @@ import { PlexAPIClient } from "../trakt/sync.js";
 import { PlexMovie, PlexEpisode, PlexWatchSession } from "../trakt/mapper.js";
 import { validatePlexId } from "../shared/utils.js";
 
+const PLEX_DISCOVER_BASE_URL = "https://discover.provider.plex.tv";
+
 export class PlexClient implements PlexAPIClient {
   constructor(private config: PlexConfig) {
     // Strip trailing slashes to prevent double-slash in URLs
-    this.config = { ...config, baseUrl: config.baseUrl.replace(/\/+$/, "") };
+    this.config = {
+      ...config,
+      baseUrl: config.baseUrl.replace(/\/+$/, ""),
+      clientIdentifier: config.clientIdentifier || "plex-mcp-server",
+    };
   }
 
   async makeRequest(endpoint: string, params: Record<string, string | number> = {}, method: string = "GET"): Promise<Record<string, unknown>> {
@@ -29,6 +35,24 @@ export class PlexClient implements PlexAPIClient {
     };
 
     const response = await axios(url, axiosConfig);
+    return response.data;
+  }
+
+  async makeDiscoverRequest(
+    endpoint: string,
+    params: Record<string, string | number> = {},
+    method: string = "GET"
+  ): Promise<Record<string, unknown>> {
+    const response = await axios(`${PLEX_DISCOVER_BASE_URL}${endpoint}`, {
+      method,
+      headers: {
+        "X-Plex-Token": this.config.token,
+        "X-Plex-Client-Identifier": this.config.clientIdentifier,
+        "X-Plex-Product": "plex-mcp-server",
+        Accept: "application/json",
+      },
+      params,
+    });
     return response.data;
   }
 

--- a/src/plex/tool-registry.ts
+++ b/src/plex/tool-registry.ts
@@ -257,7 +257,10 @@ export function createPlexToolRegistry(tools: PlexTools, options: ToolRegistryOp
   ));
 
   registry.register("remove_from_watchlist", guardMutativeOp((args) =>
-    tools.removeFromWatchlist(args.ratingKey as string)
+    tools.removeFromWatchlist({
+      ratingKey: args.ratingKey as string | undefined,
+      plexGuid: args.plexGuid as string | undefined,
+    })
   ));
 
   return registry;

--- a/src/plex/tool-schemas.ts
+++ b/src/plex/tool-schemas.ts
@@ -432,11 +432,11 @@ const DELETE_PLAYLIST_SCHEMA = {
 
 const ADD_TO_WATCHLIST_SCHEMA = {
   name: "add_to_watchlist",
-  description: "Add a media item to watchlist (requires PLEX_ENABLE_MUTATIVE_OPS=true)",
+  description: "Add a local Plex movie or show to the account watchlist (requires PLEX_ENABLE_MUTATIVE_OPS=true)",
   inputSchema: {
     type: "object" as const,
     properties: {
-      ratingKey: { type: "string", description: "The rating key of the media item" },
+      ratingKey: { type: "string", description: "Local Plex rating key for a matched movie or show" },
     },
     required: ["ratingKey"],
   },
@@ -444,13 +444,17 @@ const ADD_TO_WATCHLIST_SCHEMA = {
 
 const REMOVE_FROM_WATCHLIST_SCHEMA = {
   name: "remove_from_watchlist",
-  description: "Remove a media item from watchlist (requires PLEX_ENABLE_MUTATIVE_OPS=true)",
+  description: "Remove a movie or show from the account watchlist by global Plex GUID or local rating key (requires PLEX_ENABLE_MUTATIVE_OPS=true)",
   inputSchema: {
     type: "object" as const,
     properties: {
-      ratingKey: { type: "string", description: "The rating key of the media item" },
+      plexGuid: { type: "string", description: "Global Plex GUID returned by get_watchlist, such as plex://movie/abc123" },
+      ratingKey: { type: "string", description: "Local numeric Plex rating key; resolved to a global GUID before removal" },
     },
-    required: ["ratingKey"],
+    oneOf: [
+      { required: ["plexGuid"], not: { required: ["ratingKey"] } },
+      { required: ["ratingKey"], not: { required: ["plexGuid"] } },
+    ],
   },
 };
 export const PLEX_CORE_TOOL_SCHEMAS = [

--- a/src/plex/tools.ts
+++ b/src/plex/tools.ts
@@ -324,36 +324,24 @@ export class PlexTools {
   }
 
   async getWatchlist(): Promise<MCPResponse> {
-    const endpoints = ["/library/sections/watchlist/all", "/library/metadata/watchlist"];
-    const errors: string[] = [];
-
-    for (const endpoint of endpoints) {
-      try {
-        const data = await this.client.makeRequest(endpoint);
-        const container = data as { MediaContainer?: { Metadata?: Record<string, unknown>[] } };
-        const watchlist = container.MediaContainer?.Metadata || [];
-
-        return jsonResponse({
-          watchlist: watchlist.map((item) => ({
-            ratingKey: item.ratingKey,
-            title: item.title,
-            type: item.type,
-            year: item.year,
-            summary: item.summary ? truncate(String(item.summary), SUMMARY_PREVIEW_LENGTH) : undefined,
-            addedAt: item.addedAt,
-          })),
-          ...(endpoint !== endpoints[0] ? { note: "Retrieved using fallback watchlist endpoint" } : {}),
-        });
-      } catch (error) {
-        errors.push(`${endpoint}: ${this.getErrorMessage(error)}`);
-      }
-    }
-
+    const data = await this.client.makeDiscoverRequest(
+      "/library/sections/watchlist/all",
+      { includeCollections: 1, includeExternalMedia: 1 },
+      "GET"
+    );
+    const container = data as { MediaContainer?: { Metadata?: Record<string, unknown>[] } };
+    const watchlist = container.MediaContainer?.Metadata || [];
     return jsonResponse({
-      watchlist: [],
-      error: "Watchlist not available",
-      message: "Your Plex server may not have the watchlist feature enabled or accessible through the API",
-      errors,
+      watchlist: watchlist.map((item) => ({
+        ratingKey: item.ratingKey,
+        guid: item.guid,
+        title: item.title,
+        type: item.type,
+        year: item.year,
+        summary: item.summary ? truncate(String(item.summary), SUMMARY_PREVIEW_LENGTH) : undefined,
+        addedAt: item.watchlistedAt ?? item.addedAt,
+      })),
+      source: "Plex Discover account watchlist",
     });
   }
 
@@ -891,51 +879,42 @@ export class PlexTools {
   async addToWatchlist(ratingKey: string): Promise<MCPResponse> {
     this.requireMutativeOpsEnabled("add_to_watchlist");
     validatePlexId(ratingKey, "ratingKey");
+    const plexGuid = await this.getPlexGuid(ratingKey);
 
-    const attempts = [
-      { endpoint: "/actions/addToWatchlist", method: "GET", params: { ratingKey } as Record<string, string | number> },
-      { endpoint: `/library/metadata/${ratingKey}/watchlist`, method: "PUT", params: {} as Record<string, string | number> },
-    ];
-    const errors: string[] = [];
-
-    for (const attempt of attempts) {
-      try {
-        await this.client.makeRequest(attempt.endpoint, attempt.params, attempt.method);
-        return jsonResponse({ updated: true, action: "add_to_watchlist", ratingKey, endpoint: attempt.endpoint });
-      } catch (error) {
-        errors.push(`${attempt.method} ${attempt.endpoint}: ${this.getErrorMessage(error)}`);
-      }
-    }
-
-    throw new McpError(
-      ErrorCode.InternalError,
-      `Unable to add ${ratingKey} to watchlist. Attempts: ${errors.join(" | ")}`
+    await this.client.makeDiscoverRequest(
+      "/actions/addToWatchlist",
+      { ratingKey: this.getGlobalRatingKey(plexGuid) },
+      "PUT"
     );
+    return jsonResponse({ updated: true, action: "add_to_watchlist", ratingKey, plexGuid });
   }
 
-  async removeFromWatchlist(ratingKey: string): Promise<MCPResponse> {
+  async removeFromWatchlist(
+    input: string | { ratingKey?: string; plexGuid?: string }
+  ): Promise<MCPResponse> {
     this.requireMutativeOpsEnabled("remove_from_watchlist");
-    validatePlexId(ratingKey, "ratingKey");
-
-    const attempts = [
-      { endpoint: "/actions/removeFromWatchlist", method: "GET", params: { ratingKey } as Record<string, string | number> },
-      { endpoint: `/library/metadata/${ratingKey}/watchlist`, method: "DELETE", params: {} as Record<string, string | number> },
-    ];
-    const errors: string[] = [];
-
-    for (const attempt of attempts) {
-      try {
-        await this.client.makeRequest(attempt.endpoint, attempt.params, attempt.method);
-        return jsonResponse({ updated: true, action: "remove_from_watchlist", ratingKey, endpoint: attempt.endpoint });
-      } catch (error) {
-        errors.push(`${attempt.method} ${attempt.endpoint}: ${this.getErrorMessage(error)}`);
-      }
+    const normalized = typeof input === "string" ? { ratingKey: input } : input;
+    if (Boolean(normalized.ratingKey) === Boolean(normalized.plexGuid)) {
+      throw new McpError(
+        ErrorCode.InvalidRequest,
+        "Provide exactly one of ratingKey or plexGuid"
+      );
     }
+    const plexGuid = normalized.plexGuid
+      ? this.validatePlexGuid(normalized.plexGuid)
+      : await this.getPlexGuid(validatePlexId(normalized.ratingKey, "ratingKey"));
 
-    throw new McpError(
-      ErrorCode.InternalError,
-      `Unable to remove ${ratingKey} from watchlist. Attempts: ${errors.join(" | ")}`
+    await this.client.makeDiscoverRequest(
+      "/actions/removeFromWatchlist",
+      { ratingKey: this.getGlobalRatingKey(plexGuid) },
+      "PUT"
     );
+    return jsonResponse({
+      updated: true,
+      action: "remove_from_watchlist",
+      ratingKey: normalized.ratingKey,
+      plexGuid,
+    });
   }
 
   async getRecentlyWatched(limit: number = DEFAULT_LIMITS.recentlyWatched, mediaType: string = "all"): Promise<MCPResponse> {
@@ -1452,6 +1431,26 @@ export class PlexTools {
     }
 
     return { item, libraryKey: String(libraryKey) };
+  }
+
+  private async getPlexGuid(ratingKey: string): Promise<string> {
+    const data = await this.client.makeRequest(`/library/metadata/${ratingKey}`);
+    const container = data as { MediaContainer?: { Metadata?: Array<Record<string, unknown>> } };
+    return this.validatePlexGuid(container.MediaContainer?.Metadata?.[0]?.guid);
+  }
+
+  private validatePlexGuid(value: unknown): string {
+    if (typeof value !== "string" || !/^plex:\/\/(movie|show)\/[^/?#]+$/.test(value)) {
+      throw new McpError(
+        ErrorCode.InvalidRequest,
+        "Watchlist items must be matched with the Plex Movie or Plex TV Series agent"
+      );
+    }
+    return value;
+  }
+
+  private getGlobalRatingKey(plexGuid: string): string {
+    return plexGuid.slice(plexGuid.lastIndexOf("/") + 1);
   }
 
   private async setPosterFromUrl(

--- a/src/plex/types.ts
+++ b/src/plex/types.ts
@@ -5,6 +5,7 @@
 export interface PlexConfig {
   baseUrl: string;
   token: string;
+  clientIdentifier?: string;
 }
 
 export interface MCPResponse {


### PR DESCRIPTION
## Summary

- route `get_watchlist`, `add_to_watchlist`, and `remove_from_watchlist` through Plex Discover
- translate local Plex rating keys to global `plex://` GUIDs for account-level mutations
- let `remove_from_watchlist` consume the global GUID returned by `get_watchlist`, while preserving local numeric IDs and the legacy direct method signature
- document the account-level behavior and add focused regression coverage

## Root cause

Universal Watchlist is Plex account data served by the Discover provider. The existing implementation sent provider-relative paths to the configured local Plex Media Server and used local numeric rating keys. Those requests are not the supported Watchlist contract and return non-2xx responses on real servers.

## Compatibility

- `add_to_watchlist` continues to accept a local numeric rating key
- `remove_from_watchlist` accepts either a global `plexGuid` or a local numeric `ratingKey`
- direct library calls using `removeFromWatchlist("42")` remain supported
- legacy and third-party-agent GUIDs fail with an actionable validation error before any cloud mutation

## Validation

- `npm test` - 250 tests passed across 17 files
- `npm run build` - TypeScript compilation passed
- `git diff --check` - clean
- authenticated live round trip against Plex: selected a matched movie outside the account Watchlist, added it, observed it in `get_watchlist`, removed it by the returned global GUID, observed its removal, and restored the original 20-item state

## Scope

This PR intentionally contains no new MCP tools. Watched/unwatched controls and media ratings are proposed separately so this remains a focused Watchlist bug fix.
