### PR TITLE
feat: add opt-in watched and unwatched tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Added
+
+- Add opt-in `mark_watched` and `mark_unwatched` tools for changing Plex playback state.
+
 ## [1.4.1](https://github.com/niavasha/plex-mcp-server/compare/v1.4.0...v1.4.1) (2026-08-08)
 
 

--- a/README.md
+++ b/README.md
@@ -27,14 +27,14 @@ This MCP server transforms your Plex Media Server into an AI-queryable database.
 
 ## Features
 
-**46 tools** out of the box (55 with write operations enabled):
+**46 tools** out of the box (57 with write operations enabled):
 
 - **Plex Library Management** — Browse libraries, search media, get detailed metadata, list playlists and watchlist
 - **Tautulli-Style Analytics** — Viewing statistics, user activity, popular content, watch history
 - **Personalized Recommendations** — AI-powered movie suggestions based on your watch history, genres, directors, and actors. Supports per-user profiles for multi-user Plex servers.
 - **Sonarr/Radarr Integration** — Browse, search, add series/movies, view queues, trigger downloads
 - **Trakt.tv Sync** — OAuth authentication, watch history sync, enhanced statistics, scrobbling. When configured, Trakt data enriches recommendations by catching movies watched outside Plex.
-- **Write Operations** (opt-in) — Create/edit playlists, update metadata, manage watchlist
+- **Write Operations** (opt-in) — Create/edit playlists, update metadata, manage watchlist, and mark media watched or unwatched
 
 > **One server, all tools.** Trakt and Sonarr/Radarr credentials are optional — tools that need them return a helpful setup message if the key is missing. You don't need to configure everything upfront.
 
@@ -155,7 +155,7 @@ Once configured, you can ask your AI assistant:
 
 ## Available Functions
 
-46 tools out of the box (55 with write operations enabled).
+46 tools out of the box (57 with write operations enabled).
 
 ### Plex Tools (20 tools)
 
@@ -182,7 +182,7 @@ Once configured, you can ask your AI assistant:
 | `get_recommendations` | Personalized movie recommendations based on your watch history |
 | `get_active_sessions` | Currently active Plex streams — who is watching what, player state, transcoding |
 
-### Write Operations (9 tools, opt-in)
+### Write Operations (11 tools, opt-in)
 
 Set `PLEX_ENABLE_MUTATIVE_OPS=true` to enable these tools. They allow your AI assistant to make changes to your Plex server. **Use with care** — while we test these tools, there are no guarantees. Review changes your assistant proposes before confirming.
 
@@ -197,6 +197,8 @@ Set `PLEX_ENABLE_MUTATIVE_OPS=true` to enable these tools. They allow your AI as
 | `delete_playlist` | Delete a playlist without deleting the underlying media |
 | `add_to_watchlist` | Add a media item to the Plex watchlist |
 | `remove_from_watchlist` | Remove a media item from the Plex watchlist |
+| `mark_watched` | Mark a media item as watched |
+| `mark_unwatched` | Mark a media item as unwatched |
 
 ### Sonarr Tools (8 tools)
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "plex-mcp-server",
   "version": "1.4.1",
-  "description": "Unified MCP server for Plex, Sonarr, Radarr, and Trakt — 45 AI tools for managing your media library with personalized recommendations (54 with write operations enabled)",
+  "description": "Unified MCP server for Plex, Sonarr, Radarr, and Trakt — 46 AI tools for managing your media library with personalized recommendations (57 with write operations enabled)",
   "type": "module",
   "main": "build/plex-mcp-server.js",
   "bin": {

--- a/src/__tests__/plex-tools.test.ts
+++ b/src/__tests__/plex-tools.test.ts
@@ -7,6 +7,8 @@ import { SUMMARY_PREVIEW_LENGTH, DEFAULT_LIMITS } from "../plex/constants.js";
 function createMockClient() {
   return {
     makeRequest: vi.fn(),
+    markAsWatched: vi.fn(),
+    markAsUnwatched: vi.fn(),
     getPlexTypeId: vi.fn((type: string) => {
       const ids: Record<string, number> = { movie: 1, show: 2, episode: 4 };
       return ids[type] || 1;
@@ -162,6 +164,52 @@ describe("PlexTools", () => {
 
       const result = parseResponse(await tools.getWatchlist());
       expect(result.watchlist[0].summary.length).toBeLessThanOrEqual(SUMMARY_PREVIEW_LENGTH + 3);
+    });
+  });
+
+  describe("watch-state actions", () => {
+    const originalMutativeEnv = process.env.PLEX_ENABLE_MUTATIVE_OPS;
+
+    beforeEach(() => {
+      process.env.PLEX_ENABLE_MUTATIVE_OPS = "true";
+    });
+
+    afterEach(() => {
+      if (originalMutativeEnv === undefined) {
+        delete process.env.PLEX_ENABLE_MUTATIVE_OPS;
+      } else {
+        process.env.PLEX_ENABLE_MUTATIVE_OPS = originalMutativeEnv;
+      }
+    });
+
+    it("marks an item watched through the dedicated client operation", async () => {
+      const result = parseResponse(await tools.markWatched("42"));
+
+      expect(client.markAsWatched).toHaveBeenCalledWith("42");
+      expect(result).toEqual({ updated: true, watched: true, ratingKey: "42" });
+    });
+
+    it("marks an item unwatched through the dedicated client operation", async () => {
+      const result = parseResponse(await tools.markUnwatched("42"));
+
+      expect(client.markAsUnwatched).toHaveBeenCalledWith("42");
+      expect(result).toEqual({ updated: true, watched: false, ratingKey: "42" });
+    });
+
+    it("keeps both actions behind the mutative-operations opt-in", async () => {
+      delete process.env.PLEX_ENABLE_MUTATIVE_OPS;
+
+      await expect(tools.markWatched("42")).rejects.toThrow(/PLEX_ENABLE_MUTATIVE_OPS/);
+      await expect(tools.markUnwatched("42")).rejects.toThrow(/PLEX_ENABLE_MUTATIVE_OPS/);
+      expect(client.markAsWatched).not.toHaveBeenCalled();
+      expect(client.markAsUnwatched).not.toHaveBeenCalled();
+    });
+
+    it("rejects invalid local rating keys before calling Plex", async () => {
+      await expect(tools.markWatched("not-a-key")).rejects.toThrow(/numeric Plex ID/);
+      await expect(tools.markUnwatched("not-a-key")).rejects.toThrow(/numeric Plex ID/);
+      expect(client.markAsWatched).not.toHaveBeenCalled();
+      expect(client.markAsUnwatched).not.toHaveBeenCalled();
     });
   });
 

--- a/src/__tests__/plex-watch-state-client.test.ts
+++ b/src/__tests__/plex-watch-state-client.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it, vi } from "vitest";
+import { PlexClient } from "../plex/client.js";
+
+describe("PlexClient watch-state operations", () => {
+  it("marks media watched with Plex's scrobble endpoint", async () => {
+    const client = new PlexClient({ baseUrl: "http://localhost:32400", token: "test-token" });
+    const request = vi.spyOn(client, "makeRequest").mockResolvedValue({});
+
+    await client.markAsWatched("42");
+
+    expect(request).toHaveBeenCalledWith("/:/scrobble", {
+      key: "42",
+      identifier: "com.plexapp.plugins.library",
+    });
+  });
+
+  it("marks media unwatched with Plex's unscrobble endpoint", async () => {
+    const client = new PlexClient({ baseUrl: "http://localhost:32400", token: "test-token" });
+    const request = vi.spyOn(client, "makeRequest").mockResolvedValue({});
+
+    await client.markAsUnwatched("42");
+
+    expect(request).toHaveBeenCalledWith("/:/unscrobble", {
+      key: "42",
+      identifier: "com.plexapp.plugins.library",
+    });
+  });
+});

--- a/src/__tests__/tool-annotations.test.ts
+++ b/src/__tests__/tool-annotations.test.ts
@@ -97,6 +97,8 @@ describe("safe-by-default classification", () => {
       "create_playlist",
       "add_to_playlist",
       "add_to_watchlist",
+      "mark_watched",
+      "mark_unwatched",
       "export_library",
       "sonarr_add_series",
       "radarr_add_movie",

--- a/src/__tests__/unified-server.test.ts
+++ b/src/__tests__/unified-server.test.ts
@@ -31,10 +31,10 @@ describe("Unified server — tool registration", () => {
     expect(new Set(names).size).toBe(46);
   });
 
-  it("registers exactly 55 tools with mutative ops", () => {
+  it("registers exactly 57 tools with mutative ops", () => {
     const names = allSchemasWithMutative.map((s) => s.name);
-    expect(names).toHaveLength(55);
-    expect(new Set(names).size).toBe(55);
+    expect(names).toHaveLength(57);
+    expect(new Set(names).size).toBe(57);
   });
 
   it("includes plex core tools", () => {
@@ -79,6 +79,8 @@ describe("Unified server — tool registration", () => {
     expect(names).toContain("update_metadata");
     expect(names).toContain("create_playlist");
     expect(names).toContain("add_to_watchlist");
+    expect(names).toContain("mark_watched");
+    expect(names).toContain("mark_unwatched");
     expect(names).toContain("delete_playlist");
   });
 
@@ -140,6 +142,8 @@ describe("Unified server — dispatch routing", () => {
     expect(plexRegistry.has("search_media")).toBe(true);
     expect(plexRegistry.has("get_fully_watched")).toBe(true);
     expect(plexRegistry.has("update_metadata")).toBe(true);
+    expect(plexRegistry.has("mark_watched")).toBe(true);
+    expect(plexRegistry.has("mark_unwatched")).toBe(true);
   });
 
   it("trakt registry owns trakt tools", () => {

--- a/src/plex/client.ts
+++ b/src/plex/client.ts
@@ -175,6 +175,14 @@ export class PlexClient implements PlexAPIClient {
     });
   }
 
+  async markAsUnwatched(ratingKey: string): Promise<void> {
+    validatePlexId(ratingKey, "ratingKey");
+    await this.makeRequest("/:/unscrobble", {
+      key: ratingKey,
+      identifier: "com.plexapp.plugins.library",
+    });
+  }
+
   async updateProgress(ratingKey: string, progress: number, userId?: number): Promise<void> {
     validatePlexId(ratingKey, "ratingKey");
     await this.makeRequest("/:/progress", {

--- a/src/plex/tool-registry.ts
+++ b/src/plex/tool-registry.ts
@@ -260,5 +260,13 @@ export function createPlexToolRegistry(tools: PlexTools, options: ToolRegistryOp
     tools.removeFromWatchlist(args.ratingKey as string)
   ));
 
+  registry.register("mark_watched", guardMutativeOp((args) =>
+    tools.markWatched(args.ratingKey as string)
+  ));
+
+  registry.register("mark_unwatched", guardMutativeOp((args) =>
+    tools.markUnwatched(args.ratingKey as string)
+  ));
+
   return registry;
 }

--- a/src/plex/tool-schemas.ts
+++ b/src/plex/tool-schemas.ts
@@ -453,6 +453,30 @@ const REMOVE_FROM_WATCHLIST_SCHEMA = {
     required: ["ratingKey"],
   },
 };
+
+const MARK_WATCHED_SCHEMA = {
+  name: "mark_watched",
+  description: "Mark a Plex media item as watched (requires PLEX_ENABLE_MUTATIVE_OPS=true)",
+  inputSchema: {
+    type: "object" as const,
+    properties: {
+      ratingKey: { type: "string", description: "The local Plex rating key of the media item" },
+    },
+    required: ["ratingKey"],
+  },
+};
+
+const MARK_UNWATCHED_SCHEMA = {
+  name: "mark_unwatched",
+  description: "Mark a Plex media item as unwatched (requires PLEX_ENABLE_MUTATIVE_OPS=true)",
+  inputSchema: {
+    type: "object" as const,
+    properties: {
+      ratingKey: { type: "string", description: "The local Plex rating key of the media item" },
+    },
+    required: ["ratingKey"],
+  },
+};
 export const PLEX_CORE_TOOL_SCHEMAS = [
   GET_LIBRARIES_SCHEMA,
   GET_LIBRARY_ITEMS_SCHEMA,
@@ -511,7 +535,7 @@ const PLEX_EXTENDED_TOOL_SCHEMAS = [
 ];
 
 /** All Plex tool schemas */
-/** Mutative tools (9 tools) — registered only when opt-in is enabled */
+/** Mutative tools (11 tools) — registered only when opt-in is enabled */
 export const PLEX_MUTATIVE_TOOL_SCHEMAS = [
   UPDATE_METADATA_SCHEMA,
   UPDATE_METADATA_FROM_JSON_SCHEMA,
@@ -522,6 +546,8 @@ export const PLEX_MUTATIVE_TOOL_SCHEMAS = [
   DELETE_PLAYLIST_SCHEMA,
   ADD_TO_WATCHLIST_SCHEMA,
   REMOVE_FROM_WATCHLIST_SCHEMA,
+  MARK_WATCHED_SCHEMA,
+  MARK_UNWATCHED_SCHEMA,
 ];
 export const PLEX_TOOL_SCHEMAS = [
   ...PLEX_CORE_TOOL_SCHEMAS,

--- a/src/plex/tools.ts
+++ b/src/plex/tools.ts
@@ -938,6 +938,20 @@ export class PlexTools {
     );
   }
 
+  async markWatched(ratingKey: string): Promise<MCPResponse> {
+    this.requireMutativeOpsEnabled("mark_watched");
+    validatePlexId(ratingKey, "ratingKey");
+    await this.client.markAsWatched(ratingKey);
+    return jsonResponse({ updated: true, watched: true, ratingKey });
+  }
+
+  async markUnwatched(ratingKey: string): Promise<MCPResponse> {
+    this.requireMutativeOpsEnabled("mark_unwatched");
+    validatePlexId(ratingKey, "ratingKey");
+    await this.client.markAsUnwatched(ratingKey);
+    return jsonResponse({ updated: true, watched: false, ratingKey });
+  }
+
   async getRecentlyWatched(limit: number = DEFAULT_LIMITS.recentlyWatched, mediaType: string = "all"): Promise<MCPResponse> {
     // Primary: use watch history endpoint
     try {


### PR DESCRIPTION
## Summary

Add two opt-in Plex MCP tools for explicitly changing a local media item's playback state:

- `mark_watched`
- `mark_unwatched`

This PR is intentionally limited to watch-state changes. It does not include the account Watchlist routing fix or media-rating support.

## Implementation

- Expose the existing Plex `/:/scrobble` operation through `mark_watched`.
- Add a matching `/:/unscrobble` client operation and expose it through `mark_unwatched`.
- Require numeric local Plex rating keys before any server request.
- Keep both tools behind `PLEX_ENABLE_MUTATIVE_OPS=true` at both dispatch and tool-method boundaries.
- Advertise both operations as reversible, non-read-only MCP tools.
- Update tool counts and user documentation.

## Safety and compatibility

- Both tools are absent from the default advertised tool set unless write operations are enabled.
- Invalid identifiers fail before Plex is called.
- Existing tool names and behavior are unchanged.
- The branch is based directly on the current upstream `main` and has one focused commit.

## Verification

- `npm test -- --run` - 17 files, 249 tests passed.
- `npm run build` - TypeScript build passed.
- `git diff --check` - passed.
- Live Plex smoke test through the built MCP registry:
  - selected an initially unwatched movie;
  - invoked `mark_watched` and observed `viewCount` become watched;
  - invoked `mark_unwatched` and observed `viewCount` return to unwatched;
  - confirmed the item's original state was restored.

The test suite covers endpoint contracts, tool responses, opt-in gating, identifier validation, schema registration, registry ownership, annotations, and documentation counts.
