### PR TITLE
feat: add opt-in Plex media rating tool

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Added
+
+- Add an opt-in `rate_media` tool for setting a Plex user's media rating.
+
 ## [1.4.1](https://github.com/niavasha/plex-mcp-server/compare/v1.4.0...v1.4.1) (2026-08-08)
 
 

--- a/README.md
+++ b/README.md
@@ -27,14 +27,14 @@ This MCP server transforms your Plex Media Server into an AI-queryable database.
 
 ## Features
 
-**46 tools** out of the box (55 with write operations enabled):
+**46 tools** out of the box (56 with write operations enabled):
 
 - **Plex Library Management** — Browse libraries, search media, get detailed metadata, list playlists and watchlist
 - **Tautulli-Style Analytics** — Viewing statistics, user activity, popular content, watch history
 - **Personalized Recommendations** — AI-powered movie suggestions based on your watch history, genres, directors, and actors. Supports per-user profiles for multi-user Plex servers.
 - **Sonarr/Radarr Integration** — Browse, search, add series/movies, view queues, trigger downloads
 - **Trakt.tv Sync** — OAuth authentication, watch history sync, enhanced statistics, scrobbling. When configured, Trakt data enriches recommendations by catching movies watched outside Plex.
-- **Write Operations** (opt-in) — Create/edit playlists, update metadata, manage watchlist
+- **Write Operations** (opt-in) — Create/edit playlists, update metadata, manage watchlist, and rate media
 
 > **One server, all tools.** Trakt and Sonarr/Radarr credentials are optional — tools that need them return a helpful setup message if the key is missing. You don't need to configure everything upfront.
 
@@ -155,7 +155,7 @@ Once configured, you can ask your AI assistant:
 
 ## Available Functions
 
-46 tools out of the box (55 with write operations enabled).
+46 tools out of the box (56 with write operations enabled).
 
 ### Plex Tools (20 tools)
 
@@ -182,7 +182,7 @@ Once configured, you can ask your AI assistant:
 | `get_recommendations` | Personalized movie recommendations based on your watch history |
 | `get_active_sessions` | Currently active Plex streams — who is watching what, player state, transcoding |
 
-### Write Operations (9 tools, opt-in)
+### Write Operations (10 tools, opt-in)
 
 Set `PLEX_ENABLE_MUTATIVE_OPS=true` to enable these tools. They allow your AI assistant to make changes to your Plex server. **Use with care** — while we test these tools, there are no guarantees. Review changes your assistant proposes before confirming.
 
@@ -197,6 +197,7 @@ Set `PLEX_ENABLE_MUTATIVE_OPS=true` to enable these tools. They allow your AI as
 | `delete_playlist` | Delete a playlist without deleting the underlying media |
 | `add_to_watchlist` | Add a media item to the Plex watchlist |
 | `remove_from_watchlist` | Remove a media item from the Plex watchlist |
+| `rate_media` | Set the user's rating for a media item from 0 to 10 |
 
 ### Sonarr Tools (8 tools)
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "plex-mcp-server",
   "version": "1.4.1",
-  "description": "Unified MCP server for Plex, Sonarr, Radarr, and Trakt — 45 AI tools for managing your media library with personalized recommendations (54 with write operations enabled)",
+  "description": "Unified MCP server for Plex, Sonarr, Radarr, and Trakt — 46 AI tools for managing your media library with personalized recommendations (56 with write operations enabled)",
   "type": "module",
   "main": "build/plex-mcp-server.js",
   "bin": {

--- a/src/__tests__/plex-rating-client.test.ts
+++ b/src/__tests__/plex-rating-client.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it, vi } from "vitest";
+import { PlexClient } from "../plex/client.js";
+
+describe("PlexClient media rating", () => {
+  it("sets the user's rating with Plex's rate endpoint", async () => {
+    const client = new PlexClient({ baseUrl: "http://localhost:32400", token: "test-token" });
+    const request = vi.spyOn(client, "makeRequest").mockResolvedValue({});
+
+    await client.rateMedia("42", 8.5);
+
+    expect(request).toHaveBeenCalledWith(
+      "/:/rate",
+      {
+        key: "42",
+        identifier: "com.plexapp.plugins.library",
+        rating: 8.5,
+      },
+      "PUT"
+    );
+  });
+});

--- a/src/__tests__/plex-tools.test.ts
+++ b/src/__tests__/plex-tools.test.ts
@@ -7,6 +7,7 @@ import { SUMMARY_PREVIEW_LENGTH, DEFAULT_LIMITS } from "../plex/constants.js";
 function createMockClient() {
   return {
     makeRequest: vi.fn(),
+    rateMedia: vi.fn(),
     getPlexTypeId: vi.fn((type: string) => {
       const ids: Record<string, number> = { movie: 1, show: 2, episode: 4 };
       return ids[type] || 1;
@@ -162,6 +163,49 @@ describe("PlexTools", () => {
 
       const result = parseResponse(await tools.getWatchlist());
       expect(result.watchlist[0].summary.length).toBeLessThanOrEqual(SUMMARY_PREVIEW_LENGTH + 3);
+    });
+  });
+
+  describe("media rating action", () => {
+    const originalMutativeEnv = process.env.PLEX_ENABLE_MUTATIVE_OPS;
+
+    beforeEach(() => {
+      process.env.PLEX_ENABLE_MUTATIVE_OPS = "true";
+    });
+
+    afterEach(() => {
+      if (originalMutativeEnv === undefined) {
+        delete process.env.PLEX_ENABLE_MUTATIVE_OPS;
+      } else {
+        process.env.PLEX_ENABLE_MUTATIVE_OPS = originalMutativeEnv;
+      }
+    });
+
+    it.each([0, 8.5, 10])("sets a valid Plex user rating of %s", async (rating) => {
+      const result = parseResponse(await tools.rateMedia("42", rating));
+
+      expect(client.rateMedia).toHaveBeenCalledWith("42", rating);
+      expect(result).toEqual({ updated: true, ratingKey: "42", rating });
+    });
+
+    it.each([-0.1, 10.1, Number.NaN, Number.POSITIVE_INFINITY])(
+      "rejects an invalid Plex user rating of %s",
+      async (rating) => {
+        await expect(tools.rateMedia("42", rating)).rejects.toThrow(/between 0 and 10/i);
+        expect(client.rateMedia).not.toHaveBeenCalled();
+      }
+    );
+
+    it("keeps rating behind the mutative-operations opt-in", async () => {
+      delete process.env.PLEX_ENABLE_MUTATIVE_OPS;
+
+      await expect(tools.rateMedia("42", 8)).rejects.toThrow(/PLEX_ENABLE_MUTATIVE_OPS/);
+      expect(client.rateMedia).not.toHaveBeenCalled();
+    });
+
+    it("rejects invalid local rating keys before calling Plex", async () => {
+      await expect(tools.rateMedia("not-a-key", 8)).rejects.toThrow(/numeric Plex ID/);
+      expect(client.rateMedia).not.toHaveBeenCalled();
     });
   });
 

--- a/src/__tests__/tool-annotations.test.ts
+++ b/src/__tests__/tool-annotations.test.ts
@@ -97,6 +97,7 @@ describe("safe-by-default classification", () => {
       "create_playlist",
       "add_to_playlist",
       "add_to_watchlist",
+      "rate_media",
       "export_library",
       "sonarr_add_series",
       "radarr_add_movie",

--- a/src/__tests__/unified-server.test.ts
+++ b/src/__tests__/unified-server.test.ts
@@ -31,10 +31,10 @@ describe("Unified server — tool registration", () => {
     expect(new Set(names).size).toBe(46);
   });
 
-  it("registers exactly 55 tools with mutative ops", () => {
+  it("registers exactly 56 tools with mutative ops", () => {
     const names = allSchemasWithMutative.map((s) => s.name);
-    expect(names).toHaveLength(55);
-    expect(new Set(names).size).toBe(55);
+    expect(names).toHaveLength(56);
+    expect(new Set(names).size).toBe(56);
   });
 
   it("includes plex core tools", () => {
@@ -79,7 +79,17 @@ describe("Unified server — tool registration", () => {
     expect(names).toContain("update_metadata");
     expect(names).toContain("create_playlist");
     expect(names).toContain("add_to_watchlist");
+    expect(names).toContain("rate_media");
     expect(names).toContain("delete_playlist");
+  });
+
+  it("advertises the supported Plex user-rating range", () => {
+    const schema = PLEX_MUTATIVE_TOOL_SCHEMAS.find((tool) => tool.name === "rate_media");
+    const properties = schema?.inputSchema.properties;
+    const rating = properties && "rating" in properties ? properties.rating : undefined;
+
+    expect(rating).toMatchObject({ type: "number", minimum: 0, maximum: 10 });
+    expect(schema?.inputSchema.required).toEqual(["ratingKey", "rating"]);
   });
 
   it("every tool schema has name and inputSchema", () => {
@@ -140,6 +150,7 @@ describe("Unified server — dispatch routing", () => {
     expect(plexRegistry.has("search_media")).toBe(true);
     expect(plexRegistry.has("get_fully_watched")).toBe(true);
     expect(plexRegistry.has("update_metadata")).toBe(true);
+    expect(plexRegistry.has("rate_media")).toBe(true);
   });
 
   it("trakt registry owns trakt tools", () => {

--- a/src/plex/client.ts
+++ b/src/plex/client.ts
@@ -175,6 +175,19 @@ export class PlexClient implements PlexAPIClient {
     });
   }
 
+  async rateMedia(ratingKey: string, rating: number): Promise<void> {
+    validatePlexId(ratingKey, "ratingKey");
+    await this.makeRequest(
+      "/:/rate",
+      {
+        key: ratingKey,
+        identifier: "com.plexapp.plugins.library",
+        rating,
+      },
+      "PUT"
+    );
+  }
+
   async updateProgress(ratingKey: string, progress: number, userId?: number): Promise<void> {
     validatePlexId(ratingKey, "ratingKey");
     await this.makeRequest("/:/progress", {

--- a/src/plex/tool-registry.ts
+++ b/src/plex/tool-registry.ts
@@ -260,5 +260,9 @@ export function createPlexToolRegistry(tools: PlexTools, options: ToolRegistryOp
     tools.removeFromWatchlist(args.ratingKey as string)
   ));
 
+  registry.register("rate_media", guardMutativeOp((args) =>
+    tools.rateMedia(args.ratingKey as string, args.rating as number)
+  ));
+
   return registry;
 }

--- a/src/plex/tool-schemas.ts
+++ b/src/plex/tool-schemas.ts
@@ -453,6 +453,24 @@ const REMOVE_FROM_WATCHLIST_SCHEMA = {
     required: ["ratingKey"],
   },
 };
+
+const RATE_MEDIA_SCHEMA = {
+  name: "rate_media",
+  description: "Set the user's Plex rating for a media item (requires PLEX_ENABLE_MUTATIVE_OPS=true)",
+  inputSchema: {
+    type: "object" as const,
+    properties: {
+      ratingKey: { type: "string", description: "The local Plex rating key of the media item" },
+      rating: {
+        type: "number",
+        description: "User rating from 0 to 10",
+        minimum: 0,
+        maximum: 10,
+      },
+    },
+    required: ["ratingKey", "rating"],
+  },
+};
 export const PLEX_CORE_TOOL_SCHEMAS = [
   GET_LIBRARIES_SCHEMA,
   GET_LIBRARY_ITEMS_SCHEMA,
@@ -511,7 +529,7 @@ const PLEX_EXTENDED_TOOL_SCHEMAS = [
 ];
 
 /** All Plex tool schemas */
-/** Mutative tools (9 tools) — registered only when opt-in is enabled */
+/** Mutative tools (10 tools) — registered only when opt-in is enabled */
 export const PLEX_MUTATIVE_TOOL_SCHEMAS = [
   UPDATE_METADATA_SCHEMA,
   UPDATE_METADATA_FROM_JSON_SCHEMA,
@@ -522,6 +540,7 @@ export const PLEX_MUTATIVE_TOOL_SCHEMAS = [
   DELETE_PLAYLIST_SCHEMA,
   ADD_TO_WATCHLIST_SCHEMA,
   REMOVE_FROM_WATCHLIST_SCHEMA,
+  RATE_MEDIA_SCHEMA,
 ];
 export const PLEX_TOOL_SCHEMAS = [
   ...PLEX_CORE_TOOL_SCHEMAS,

--- a/src/plex/tools.ts
+++ b/src/plex/tools.ts
@@ -938,6 +938,16 @@ export class PlexTools {
     );
   }
 
+  async rateMedia(ratingKey: string, rating: number): Promise<MCPResponse> {
+    this.requireMutativeOpsEnabled("rate_media");
+    validatePlexId(ratingKey, "ratingKey");
+    if (!Number.isFinite(rating) || rating < 0 || rating > 10) {
+      throw new McpError(ErrorCode.InvalidRequest, "rating must be between 0 and 10");
+    }
+    await this.client.rateMedia(ratingKey, rating);
+    return jsonResponse({ updated: true, ratingKey, rating });
+  }
+
   async getRecentlyWatched(limit: number = DEFAULT_LIMITS.recentlyWatched, mediaType: string = "all"): Promise<MCPResponse> {
     // Primary: use watch history endpoint
     try {


### PR DESCRIPTION
## Summary

Add one opt-in MCP tool, `rate_media`, for setting the current Plex user's rating on a local media item.

This PR is intentionally limited to user ratings. It does not include the account Watchlist fix or watched/unwatched state tools.

## Implementation

- Call Plex's `PUT /:/rate` endpoint with the local rating key, library identifier, and requested rating.
- Accept finite numeric ratings from 0 through 10, including both boundaries and fractional values.
- Reject out-of-range, `NaN`, infinite, and invalid-rating-key inputs before calling Plex.
- Keep the tool behind `PLEX_ENABLE_MUTATIVE_OPS=true` at both dispatch and tool-method boundaries.
- Advertise the operation as a reversible, non-read-only MCP tool.
- Document the tool and update generated tool-count expectations.

## Safety and compatibility

- `rate_media` is absent from the default advertised tool set unless write operations are enabled.
- The JSON schema declares the same 0-10 range enforced at runtime.
- Existing tool names and behavior are unchanged.
- The branch is based directly on the current upstream `main` and has one focused commit.

## Verification

- `npm test -- --run` - 17 files, 254 tests passed.
- `npm run build` - TypeScript build passed.
- `git diff --check` - passed.
- Live Plex smoke test through the built MCP registry:
  - selected an initially unrated movie;
  - invoked `rate_media` with `8` and observed `userRating=8` in Plex metadata;
  - reset the temporary rating with Plex's established `rating=-1` reset contract;
  - verified the `userRating` field was removed and the original unrated state was restored.

The endpoint and reset behavior match the established [Python-PlexAPI rating implementation](https://python-plexapi.readthedocs.io/en/latest/_modules/plexapi/mixins/rating.html).

The test suite covers the HTTP contract, valid boundaries and fractions, non-finite and out-of-range rejection, opt-in gating, identifier validation, schema constraints, registry ownership, annotations, and documentation counts.
