### PR TITLE
feat: add opt-in TOON output format for tool responses

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,12 @@ PLEX_TOKEN=your_plex_token_here
 # Disabled by default for safety. Set to true to enable.
 # PLEX_ENABLE_MUTATIVE_OPS=true
 
+# Optional: Emit tool responses as TOON instead of JSON
+# TOON is a compact, LLM-oriented encoding of the same data — noticeably fewer
+# tokens on list-shaped responses. Responses fall back to JSON whenever TOON
+# would not be shorter, so this can never make a response larger.
+# PLEX_OUTPUT_FORMAT=toon
+
 # Optional: Specify custom port for the MCP server (if needed)
 # MCP_PORT=3000
 

--- a/README.md
+++ b/README.md
@@ -102,6 +102,36 @@ npx plex-mcp-server
 
 > **Trakt.tv setup** requires a [Trakt OAuth application](https://trakt.tv/oauth/applications). Create one with redirect URI `urn:ietf:wg:oauth:2.0:oob`, then add the Client ID and Secret to your config. Once the server is running, ask your AI assistant to "authenticate with Trakt" — it will guide you through the OAuth flow. See the [Trakt setup guide](docs/trakt-setup-guide.md) for detailed instructions.
 
+### Compact Responses (optional)
+
+Tools answer with JSON by default. Setting `PLEX_OUTPUT_FORMAT=toon` switches
+them to [TOON](https://toonformat.dev), which writes an array of records once as
+a header and then as rows instead of repeating every field name on every record:
+
+```
+results[3]{ratingKey,title,year}:
+  1001,Arrival,2016
+  1002,Sicario,2015
+  1003,Dune,2021
+```
+
+That is the same data your assistant would have received, in fewer tokens —
+around a third fewer across a spread of tool responses, and 40–60% fewer on the
+list-shaped ones like `search_media`, `get_library_items` and `radarr_get_movies`.
+The saving is only worth having on long lists, so each response is emitted as
+TOON only when TOON is actually shorter, and as JSON otherwise; enabling this
+cannot make a response larger than it is today.
+
+```json
+"env": {
+  "PLEX_TOKEN": "your_plex_token_here",
+  "PLEX_OUTPUT_FORMAT": "toon"
+}
+```
+
+Leave the variable unset — the default — and responses are byte-for-byte the
+JSON they have always been.
+
 <details>
 <summary><strong>Migrating from v1.0.x?</strong></summary>
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.29.0",
+        "@toon-format/toon": "^4.1.1",
         "axios": "^1.14.0",
         "dotenv": "^17.3.1"
       },
@@ -824,6 +825,12 @@
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
       "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
       "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@toon-format/toon": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@toon-format/toon/-/toon-4.1.1.tgz",
+      "integrity": "sha512-SGCkS7IjVpwRmGPgnY8ENKpAf0EdAnZDOQkvFW0d2cgOpdn9FEFl7sTgryESyypXrWr0YajHGpwsAUX4zw9ZvA==",
       "license": "MIT"
     },
     "node_modules/@types/chai": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1936,9 +1936,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
           "type": "github",
@@ -2808,12 +2808,13 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.2",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
-      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+      "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
       "license": "BSD-3-Clause",
       "dependencies": {
-        "side-channel": "^1.1.0"
+        "es-define-property": "^1.0.1",
+        "side-channel": "^1.1.1"
       },
       "engines": {
         "node": ">=0.6"
@@ -3009,14 +3010,14 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -3028,13 +3029,13 @@
       }
     },
     "node_modules/side-channel-list": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
-      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.1.tgz",
+      "integrity": "sha512-mjn/0bi/oUURjc5Xl7IaWi/OJJJumuoJFQJfDDyO46+hBWsfaVM65TBHq2eoZBhzl9EchxOijpkbRC8SVBQU0w==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3"
+        "object-inspect": "^1.13.4"
       },
       "engines": {
         "node": ">= 0.4"

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.29.0",
+    "@toon-format/toon": "^4.1.1",
     "axios": "^1.14.0",
     "dotenv": "^17.3.1"
   },

--- a/src/__tests__/output-format.test.ts
+++ b/src/__tests__/output-format.test.ts
@@ -1,0 +1,223 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { decode } from "@toon-format/toon";
+import { PlexTools } from "../plex/tools.js";
+import { PlexClient } from "../plex/client.js";
+import { createTraktToolRegistry } from "../trakt/tool-registry.js";
+import { TraktMCPFunctions } from "../trakt/mcp-functions.js";
+import { createArrToolRegistry } from "../arr/tool-registry.js";
+import { ArrMCPFunctions } from "../arr/mcp-functions.js";
+import {
+  OUTPUT_FORMAT_ENV_VAR,
+  isToonOutputEnabled,
+  formatToolPayload,
+} from "../shared/output-format.js";
+
+/**
+ * The contract these tests defend is narrow and worth stating plainly:
+ *
+ *   1. With PLEX_OUTPUT_FORMAT unset, output is byte-for-byte what it has
+ *      always been. Existing installs cannot notice this feature exists.
+ *   2. With PLEX_OUTPUT_FORMAT=toon, output is TOON that decodes back to
+ *      exactly the value the JSON path would have produced — same keys, same
+ *      types, same omissions.
+ */
+
+const originalFormat = process.env[OUTPUT_FORMAT_ENV_VAR];
+
+function useToon() {
+  process.env[OUTPUT_FORMAT_ENV_VAR] = "toon";
+}
+
+afterEach(() => {
+  if (originalFormat === undefined) delete process.env[OUTPUT_FORMAT_ENV_VAR];
+  else process.env[OUTPUT_FORMAT_ENV_VAR] = originalFormat;
+});
+
+beforeEach(() => {
+  delete process.env[OUTPUT_FORMAT_ENV_VAR];
+});
+
+describe("isToonOutputEnabled", () => {
+  it("is off when the variable is unset", () => {
+    expect(isToonOutputEnabled()).toBe(false);
+  });
+
+  it("is off for any value other than toon", () => {
+    for (const value of ["", "json", "yaml", "true", "TOONISH"]) {
+      process.env[OUTPUT_FORMAT_ENV_VAR] = value;
+      expect(isToonOutputEnabled()).toBe(false);
+    }
+  });
+
+  it("accepts toon regardless of case or surrounding whitespace", () => {
+    for (const value of ["toon", "TOON", "Toon", " toon "]) {
+      process.env[OUTPUT_FORMAT_ENV_VAR] = value;
+      expect(isToonOutputEnabled()).toBe(true);
+    }
+  });
+});
+
+describe("formatToolPayload", () => {
+  const payload = { items: [{ id: 1, title: "A" }, { id: 2, title: "B" }] };
+
+  it("emits unchanged JSON by default", () => {
+    expect(formatToolPayload(payload)).toBe(JSON.stringify(payload));
+    expect(formatToolPayload(payload, 2)).toBe(JSON.stringify(payload, null, 2));
+  });
+
+  it("emits a tabular TOON array when enabled", () => {
+    useToon();
+    expect(formatToolPayload(payload)).toBe("items[2]{id,title}:\n  1,A\n  2,B");
+  });
+
+  it("never returns more text than plain JSON would have", () => {
+    useToon();
+    for (const indent of [undefined, 2]) {
+      expect(formatToolPayload(payload, indent).length).toBeLessThanOrEqual(
+        JSON.stringify(payload, null, indent).length
+      );
+    }
+  });
+
+  it("keeps the JSON when TOON would be longer", () => {
+    // Elements with differing keys cannot use TOON's tabular form, and its
+    // list form is the longer encoding here.
+    const ragged = { items: [{ a: 1 }, { a: 1, b: 2 }] };
+    useToon();
+    expect(formatToolPayload(ragged)).toBe(JSON.stringify(ragged));
+  });
+
+  it("drops undefined properties exactly as JSON.stringify does", () => {
+    // Several tools omit optional fields by assigning undefined. Encoding the
+    // raw value would turn those into nulls; normalizing through JSON first
+    // keeps both formats reporting the same key set.
+    const withHoles = { a: 1, summary: undefined, items: [{ id: 1, summary: undefined }] };
+    useToon();
+    expect(decode(formatToolPayload(withHoles))).toEqual(JSON.parse(JSON.stringify(withHoles)));
+    expect(formatToolPayload(withHoles)).not.toContain("summary");
+  });
+
+  it("still throws on values JSON cannot represent", () => {
+    const circular: Record<string, unknown> = { a: 1 };
+    circular.self = circular;
+    useToon();
+    expect(() => formatToolPayload(circular)).toThrow(TypeError);
+  });
+});
+
+/** Create a mock PlexClient without hitting any real server */
+function createMockClient() {
+  return {
+    makeRequest: vi.fn(),
+    makeDiscoverRequest: vi.fn(),
+    getPlexTypeId: vi.fn(() => 1),
+  } as unknown as PlexClient;
+}
+
+const SEARCH_FIXTURE = {
+  MediaContainer: {
+    Metadata: [
+      { ratingKey: "1", title: "First", type: "movie", year: 2001, summary: "One", rating: 7.5 },
+      { ratingKey: "2", title: "Second", type: "movie", year: 2002, summary: "Two", rating: 8 },
+    ],
+  },
+};
+
+/** Same tool, but the second result has no summary — a common real response. */
+const RAGGED_FIXTURE = {
+  MediaContainer: {
+    Metadata: [
+      { ratingKey: "1", title: "First", type: "movie", year: 2001, summary: "One", rating: 7.5 },
+      { ratingKey: "2", title: "Second", type: "movie", year: 2002, rating: 8 },
+    ],
+  },
+};
+
+describe("Plex tool responses", () => {
+  let client: ReturnType<typeof createMockClient>;
+  let tools: PlexTools;
+
+  beforeEach(() => {
+    client = createMockClient();
+    tools = new PlexTools(client as unknown as PlexClient);
+    (client.makeRequest as ReturnType<typeof vi.fn>).mockResolvedValue(SEARCH_FIXTURE);
+  });
+
+  it("returns pretty-printed JSON by default", async () => {
+    const text = (await tools.searchMedia("q")).content[0].text;
+    expect(text.startsWith("{\n")).toBe(true);
+    expect(JSON.parse(text).results).toHaveLength(2);
+  });
+
+  it("returns TOON that decodes to the same value when enabled", async () => {
+    const json = (await tools.searchMedia("q")).content[0].text;
+    useToon();
+    const toon = (await tools.searchMedia("q")).content[0].text;
+
+    expect(toon).not.toBe(json);
+    expect(decode(toon)).toEqual(JSON.parse(json));
+  });
+
+  it("uses the tabular form when every result carries the same fields", async () => {
+    useToon();
+    const toon = (await tools.searchMedia("q")).content[0].text;
+    expect(toon).toContain("results[2]{ratingKey,title,type,year,summary,rating}:");
+  });
+
+  it("does not grow the response when results have differing fields", async () => {
+    // Tools omit optional fields rather than sending nulls, so an array is
+    // only tabular when every element happens to have the same ones. In the
+    // ragged case TOON's list form can be the longer encoding, and then the
+    // JSON is kept instead.
+    (client.makeRequest as ReturnType<typeof vi.fn>).mockResolvedValue(RAGGED_FIXTURE);
+    const json = (await tools.searchMedia("q")).content[0].text;
+    useToon();
+    const toon = (await tools.searchMedia("q")).content[0].text;
+
+    expect(toon.length).toBeLessThanOrEqual(json.length);
+    expect(decode(toon)).toEqual(JSON.parse(json));
+  });
+});
+
+describe("Trakt tool responses", () => {
+  const traktFunctions = {
+    traktGetAuthStatus: async () => ({ authenticated: true, user: "someone" }),
+  } as unknown as TraktMCPFunctions;
+
+  it("returns compact JSON by default", async () => {
+    const registry = createTraktToolRegistry(traktFunctions);
+    const text = (await registry.handle("trakt_get_auth_status")).content[0].text;
+    expect(text).toBe('{"authenticated":true,"user":"someone"}');
+  });
+
+  it("returns equivalent TOON when enabled", async () => {
+    useToon();
+    const registry = createTraktToolRegistry(traktFunctions);
+    const text = (await registry.handle("trakt_get_auth_status")).content[0].text;
+    expect(decode(text)).toEqual({ authenticated: true, user: "someone" });
+  });
+});
+
+describe("Sonarr/Radarr tool responses", () => {
+  const queue = {
+    queue: [
+      { id: 1, title: "Ep 1", status: "downloading", progress: 42 },
+      { id: 2, title: "Ep 2", status: "queued", progress: 0 },
+    ],
+  };
+  const arrFunctions = { sonarrGetQueue: async () => queue } as unknown as ArrMCPFunctions;
+
+  it("returns compact JSON by default", async () => {
+    const registry = createArrToolRegistry(arrFunctions);
+    const text = (await registry.handle("sonarr_get_queue")).content[0].text;
+    expect(text).toBe(JSON.stringify(queue));
+  });
+
+  it("returns equivalent TOON when enabled", async () => {
+    useToon();
+    const registry = createArrToolRegistry(arrFunctions);
+    const text = (await registry.handle("sonarr_get_queue")).content[0].text;
+    expect(text).toContain("queue[2]{id,title,status,progress}:");
+    expect(decode(text)).toEqual(queue);
+  });
+});

--- a/src/arr/tool-registry.ts
+++ b/src/arr/tool-registry.ts
@@ -5,6 +5,7 @@
 
 import { ToolRegistry } from "../plex/tool-registry.js";
 import { ArrMCPFunctions } from "./mcp-functions.js";
+import { formatToolPayload } from "../shared/output-format.js";
 
 export function createArrToolRegistry(arrFunctions: ArrMCPFunctions): ToolRegistry {
   const registry = new ToolRegistry();
@@ -122,5 +123,5 @@ export function createArrToolRegistry(arrFunctions: ArrMCPFunctions): ToolRegist
 }
 
 function wrapResponse(data: Record<string, unknown>) {
-  return { content: [{ type: "text", text: JSON.stringify(data) }] };
+  return { content: [{ type: "text", text: formatToolPayload(data) }] };
 }

--- a/src/plex/tools.ts
+++ b/src/plex/tools.ts
@@ -25,10 +25,11 @@ import {
   SMART_PLAYLIST_LIBTYPE_IDS,
 } from "./constants.js";
 import { truncate, validatePlexId, sanitizeSearchQuery, validatePlexMediaContainer, validatePlexTotalSize } from "../shared/utils.js";
+import { formatToolPayload } from "../shared/output-format.js";
 
 /** Helper: wrap a JSON value as an MCP text response */
 function jsonResponse(data: unknown): MCPResponse {
-  return { content: [{ type: "text", text: JSON.stringify(data, null, 2) }] };
+  return { content: [{ type: "text", text: formatToolPayload(data, 2) }] };
 }
 
 type MetadataUpdateInput = {

--- a/src/shared/output-format.ts
+++ b/src/shared/output-format.ts
@@ -1,0 +1,73 @@
+/**
+ * Optional TOON encoding for tool responses.
+ *
+ * Every tool answers with a JSON document in an MCP text block. Those
+ * documents are overwhelmingly "some metadata plus an array of uniform
+ * records" — `search_media` returns `results`, `get_library_items` returns
+ * `items`, `sonarr_get_queue` returns `queue`. JSON repeats every field name
+ * on every record, which is pure overhead once an array gets long.
+ *
+ * TOON (Token-Oriented Object Notation) encodes such an array once as a
+ * header and then as delimited rows:
+ *
+ *   items[3]{ratingKey,title,year}:
+ *     1001,Arrival,2016
+ *     1002,Sicario,2015
+ *     1003,Dune,2021
+ *
+ * which is the same data in noticeably fewer characters — and so in fewer
+ * tokens of the model's context.
+ *
+ * ## This is opt-in
+ *
+ * `PLEX_OUTPUT_FORMAT` is unset for existing installs, so they keep getting
+ * exactly the JSON they get today, byte for byte. Only `PLEX_OUTPUT_FORMAT=toon`
+ * switches encoding, and it is read per call so tests can toggle it.
+ *
+ * ## The payload is normalized through JSON first
+ *
+ * `JSON.parse(JSON.stringify(value))` is not redundant: it collapses the value
+ * to the JSON data model *before* TOON sees it. Without it the two formats
+ * would disagree — `JSON.stringify` drops `undefined` properties while the TOON
+ * encoder would emit them as `null`, and several tools deliberately set fields
+ * to `undefined` to omit them (`summary: item.summary ? ... : undefined`).
+ * Normalizing first guarantees the invariant worth having: decoding the TOON
+ * output yields exactly the value the JSON output parses to. It also keeps the
+ * failure modes identical — a value `JSON.stringify` rejects still throws here,
+ * in the same place, with the same error.
+ *
+ * ## And TOON is only used when it actually wins
+ *
+ * The tabular form above needs every element of an array to carry the same
+ * keys. Tools omit absent optional fields rather than sending nulls, so a
+ * single record missing its `summary` or `overview` drops the whole array to
+ * TOON's one-object-per-item list form — which, measured against minified
+ * JSON, comes out *larger*. Emitting whichever encoding is shorter costs one
+ * comparison and turns "usually cheaper" into "never more expensive", which is
+ * the only version of this worth switching on by default in your own config.
+ */
+
+import { encode } from "@toon-format/toon";
+
+export const OUTPUT_FORMAT_ENV_VAR = "PLEX_OUTPUT_FORMAT";
+
+/** True when the operator asked for TOON-encoded tool responses. */
+export function isToonOutputEnabled(): boolean {
+  return process.env[OUTPUT_FORMAT_ENV_VAR]?.trim().toLowerCase() === "toon";
+}
+
+/**
+ * Serialize a tool payload for the MCP text block.
+ *
+ * @param data   The payload the tool wants to return
+ * @param indent Spaces of JSON indentation, matching `JSON.stringify`'s third
+ *               argument, and the baseline TOON has to beat to be used.
+ * @returns TOON when it is shorter than that JSON, otherwise the JSON itself
+ */
+export function formatToolPayload(data: unknown, indent?: number): string {
+  const json = JSON.stringify(data, null, indent);
+  if (!isToonOutputEnabled()) return json;
+
+  const toon = encode(JSON.parse(json));
+  return toon.length < json.length ? toon : json;
+}

--- a/src/trakt/tool-registry.ts
+++ b/src/trakt/tool-registry.ts
@@ -5,6 +5,7 @@
 
 import { ToolRegistry } from "../plex/tool-registry.js";
 import { TraktMCPFunctions } from "./mcp-functions.js";
+import { formatToolPayload } from "../shared/output-format.js";
 
 export function createTraktToolRegistry(traktFunctions: TraktMCPFunctions): ToolRegistry {
   const registry = new ToolRegistry();
@@ -64,5 +65,5 @@ export function createTraktToolRegistry(traktFunctions: TraktMCPFunctions): Tool
 }
 
 function wrapResponse(data: Record<string, unknown>) {
-  return { content: [{ type: "text", text: JSON.stringify(data) }] };
+  return { content: [{ type: "text", text: formatToolPayload(data) }] };
 }


### PR DESCRIPTION
## What this adds

An opt-in `PLEX_OUTPUT_FORMAT=toon` that encodes tool responses as
[TOON](https://toonformat.dev) instead of JSON.

Nearly every tool answers with the same shape — some metadata plus an array of
uniform records. `search_media` returns `results`, `get_library_items` returns
`items`, `radarr_get_movies` returns `movies`. JSON repeats every field name on
every record, which is pure overhead in the assistant's context once the array
gets long. TOON writes the field names once as a header and then one row per
record:

```
results[3]{ratingKey,title,year}:
  1001,Arrival,2016
  1002,Sicario,2015
  1003,Dune,2021
```

Same data, fewer tokens, and the model reads it fine.

## The default does not change

With the variable unset — which is every existing install — each tool emits
byte-for-byte the JSON it emits today, pretty-printed for Plex tools and
compact for the Sonarr/Radarr/Trakt registries, exactly as now. There is no new
tool, no changed schema, and no change to any response your users' clients
already parse.

## Measured numbers

I measured by driving the real tool code in this repo with a mocked HTTP client
and comparing the text of the MCP response in each mode, so the payload
*shapes* come from `tools.ts` and the `arr`/`trakt` mappers rather than from
anything I invented. The data itself is synthetic. Tokens are `o200k_base`.

| response | bytes today | bytes TOON | bytes saved | tokens saved |
| --- | ---: | ---: | ---: | ---: |
| `get_on_deck` (20) | 3,725 | 1,211 | 67.5% | 60.0% |
| `get_libraries` (12) | 1,924 | 783 | 59.3% | 56.2% |
| `sonarr_get_queue` (40) | 9,379 | 3,962 | 57.8% | 39.4% |
| `get_library_items` (100) | 21,161 | 9,079 | 57.1% | 50.8% |
| `trakt_search` (30) | 3,502 | 1,623 | 53.7% | 44.7% |
| `get_playlists` (25) | 10,137 | 4,743 | 53.2% | 54.1% |
| `get_playlist_items` (100) | 27,931 | 13,577 | 51.4% | 54.1% |
| `search_media` (50) | 12,245 | 6,406 | 47.7% | 51.2% |
| `get_recently_added` (50) | 12,596 | 6,730 | 46.6% | 51.1% |
| `get_watchlist` (40) | 11,748 | 6,460 | 45.0% | 47.2% |
| `radarr_get_movies` (100) | 31,070 | 17,669 | 43.1% | 42.0% |
| `get_media_details` (single item) | 465 | 366 | 21.3% | 19.7% |
| **whole basket, incl. the ragged cases below** | **243,392** | **160,932** | **33.9%** | **32.5%** |

## The catch, and what I did about it

TOON's tabular form needs every element of an array to carry the same keys.
Several tools omit an absent optional field rather than sending a null —
`summary: item.summary ? ... : undefined`, `overview: m.overview ? ... :
undefined` — so a *single* record missing its summary drops the whole array to
TOON's longer one-object-per-item list form. For the compact-JSON registries
that is a real regression: one movie without an overview made a 100-row
`radarr_get_movies` response 8% larger in bytes and 17% larger in tokens.

Rather than document that as a footgun, `formatToolPayload` emits TOON only
when TOON is actually shorter, and the JSON otherwise. It costs one string
comparison and turns "usually cheaper" into "never more expensive". In the
basket above the ragged cases now come out at exactly 0.0% rather than
negative, and no response can get larger than it is today by enabling this.

The payload is also normalized through JSON (`JSON.parse(JSON.stringify(v))`)
before encoding. That is not redundant: `JSON.stringify` drops `undefined`
properties where the TOON encoder would render them as `null`, and the tools
above rely on that dropping. Normalizing first guarantees that decoding the
TOON output yields exactly the value the JSON output parses to, and keeps the
error behaviour identical for anything JSON cannot represent.

## Which library, and why

[`@toon-format/toon`](https://github.com/toon-format/toon) v4.1.1 — the
reference implementation from the format's own repository, MIT, ESM with
bundled `.d.mts` types, and **no runtime dependencies** (the lockfile grows by
seven lines and one package).

I did not take the README's word for it. The spec ships a language-agnostic
conformance corpus as `@toon-format/spec`; I ran the encoder and decoder
against all of it and it passes **538/538** encode and decode fixtures. I also
checked the edge cases that actually matter here — `undefined` properties,
`NaN`/`Infinity`, empty arrays, non-uniform arrays, nested objects inside
tabular rows, strings containing the delimiter or newlines, and non-ASCII
titles — and every one round-trips back to the original JSON value.

## Diff size

Three call sites, all of them one-liners, because the tools already funnel
through three tiny helpers:

- `jsonResponse` in `src/plex/tools.ts` (44 call sites behind it)
- `wrapResponse` in `src/trakt/tool-registry.ts`
- `wrapResponse` in `src/arr/tool-registry.ts`

plus `src/shared/output-format.ts` (the helper, ~20 lines of code), its test,
and the docs. `src/shared/transport.ts` is untouched — that is JSON-RPC
framing, not tool output.

## What I tested

- `npm ci`, `npm run build`, `npm test` all clean on Node 24.
- Your existing 267 tests pass unmodified, which is the point: with the
  variable unset nothing observable changes.
- 17 new tests in `src/__tests__/output-format.test.ts`, following the mocked
  `PlexClient` pattern from `plex-tools.test.ts`. They cover the env var
  parsing, that the default output is byte-identical to `JSON.stringify`, that
  TOON output decodes back to exactly what the JSON output parses to across
  the Plex, Trakt and arr paths, that the ragged case does not grow the
  response, and that the output is never longer than the JSON baseline.

Happy to adjust the variable name, drop the never-larger fallback in favour of
always-TOON, or split the docs out if you would rather take this in smaller
pieces.
